### PR TITLE
fix: remove --global flag when setting user

### DIFF
--- a/.changeset/eighty-coats-pull.md
+++ b/.changeset/eighty-coats-pull.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+remove --global flag when setting user

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -3,15 +3,9 @@ import { exec } from '@actions/exec'
 import { execWithOutput, identify } from './utils.js'
 
 export const setupUser = async () => {
+  await exec('git', ['config', 'user.name', process.env.GITLAB_USER_NAME!])
   await exec('git', [
     'config',
-    '--global',
-    'user.name',
-    process.env.GITLAB_USER_NAME!,
-  ])
-  await exec('git', [
-    'config',
-    '--global',
     'user.email',
     process.env.GITLAB_CI_USER_EMAIL ||
       '"gitlab[bot]@users.noreply.gitlab.com"',


### PR DESCRIPTION
use command like this `git config --global user.name` would create a `.gitconfig` file every time when creating a MR, which is unnecessary and may cause error. Local git config is enough, tested in my own gitlab repo.

<img width="700" alt="截屏2022-10-12 10 54 28" src="https://user-images.githubusercontent.com/100665051/195239231-f31ed0c7-eef6-4a31-8f6e-5ed9b4a2d415.png">
