### PR TITLE
feat: create MR with custom target branch

### DIFF
--- a/.changeset/seven-pugs-provide.md
+++ b/.changeset/seven-pugs-provide.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+merge requests target branch can now be configured through a input environment variable

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ GitLab CI cli for [changesets](https://github.com/atlassian/changesets) like its
 
 - published - Command executed after published
 - only_changesets - Command executed on only changesets detected
+- target_branch -> The merge request target branch. Defaults to current branch
 
 ### Outputs
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,7 @@ export const main = async ({
         script: getOptionalInput('version'),
         gitlabToken: GITLAB_TOKEN!,
         mrTitle: getOptionalInput('title'),
+        mrTargetBranch: getOptionalInput('target_branch'),
         commitMessage: getOptionalInput('commit'),
         hasPublishScript,
       })

--- a/src/run.ts
+++ b/src/run.ts
@@ -202,8 +202,6 @@ export async function runVersion({
   const currentBranch = context.ref
   const versionBranch = `changeset-release/${currentBranch}`
 
-  console.log({ currentBranch, versionBranch, mrTargetBranch })
-
   const api = createApi(gitlabToken)
   const { preState } = await readChangesetState(cwd)
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -201,6 +201,9 @@ export async function runVersion({
 }: VersionOptions) {
   const currentBranch = context.ref
   const versionBranch = `changeset-release/${currentBranch}`
+
+  console.log({ currentBranch, versionBranch, mrTargetBranch })
+
   const api = createApi(gitlabToken)
   const { preState } = await readChangesetState(cwd)
 
@@ -294,7 +297,9 @@ ${
   })
   console.log(JSON.stringify(searchResult, null, 2))
   if (searchResult.length === 0) {
-    console.log('creating merge request')
+    console.log(
+      `Creating merge request from ${versionBranch} to ${mrTargetBranch}.`,
+    )
     await api.MergeRequests.create(
       context.projectId,
       versionBranch,
@@ -305,10 +310,10 @@ ${
       },
     )
   } else {
+    console.log('Found existing merge request, updating.')
     await api.MergeRequests.edit(context.projectId, searchResult[0].iid, {
       title: finalMrTitle,
       description: await mrBodyPromise,
     })
-    console.log('merge request found')
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -296,7 +296,7 @@ ${
   console.log(JSON.stringify(searchResult, null, 2))
   if (searchResult.length === 0) {
     console.log(
-      `Creating merge request from ${versionBranch} to ${mrTargetBranch}.`,
+      `creating merge request from ${versionBranch} to ${mrTargetBranch}.`,
     )
     await api.MergeRequests.create(
       context.projectId,
@@ -308,7 +308,7 @@ ${
       },
     )
   } else {
-    console.log('Found existing merge request, updating.')
+    console.log(`updating found merge request !${searchResult[0].iid}`)
     await api.MergeRequests.edit(context.projectId, searchResult[0].iid, {
       title: finalMrTitle,
       description: await mrBodyPromise,


### PR DESCRIPTION
This pr introduces a new input variable `INPUT_TARGET_BRANCH`. If set, this value will change the target branch of the created Merge Request. For context, see #69

Resolves #69 