### PR TITLE
Fix: check project directory for .npmrc first

### DIFF
--- a/.changeset/sixty-shirts-dream.md
+++ b/.changeset/sixty-shirts-dream.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+Fix: Check project directory for .npmrc first, use as default location if no .npmrc found

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,17 @@ import { URL } from 'node:url'
 
 import { getInput, setFailed, setOutput } from '@actions/core'
 import { exec } from '@actions/exec'
-import fs from 'fs-extra'
 
 import { setupUser } from './gitUtils.js'
 import readChangesetState from './readChangesetState.js'
 import { runPublish, runVersion } from './run.js'
 import type { MainCommandOptions } from './types.js'
-import { execSync, getOptionalInput, getUsername } from './utils.js'
+import {
+  execSync,
+  getOptionalInput,
+  getUsername,
+  checkPublishConfig,
+} from './utils.js'
 
 import { createApi } from './index.js'
 
@@ -21,8 +25,6 @@ export const main = async ({
     CI_PROJECT_PATH,
     GITLAB_HOST = 'https://gitlab.com',
     GITLAB_TOKEN,
-    HOME,
-    NPM_TOKEN,
     DEBUG_GITLAB_CREDENTIAL = 'false',
   } = process.env
 
@@ -68,16 +70,9 @@ export const main = async ({
         'No changesets found, attempting to publish any unpublished packages to npm',
       )
 
-      const npmrcPath = `${HOME!}/.npmrc`
-      if (fs.existsSync(npmrcPath)) {
-        console.log('Found existing .npmrc file')
-      } else if (NPM_TOKEN) {
-        console.log('No .npmrc file found, creating one')
-        fs.writeFileSync(
-          npmrcPath,
-          `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`,
-        )
-      } else {
+      const canPublish = checkPublishConfig()
+
+      if (!canPublish) {
         setFailed(
           'No `.npmrc` found nor `NPM_TOKEN` provided, unable to publish packages',
         )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,3 +159,26 @@ export const getUsername = async (api: Gitlab) => {
     ? await api.Users.current().then(currentUser => currentUser.username)
     : process.env.GITLAB_CI_USER_NAME
 }
+
+export const checkPublishConfig = (): boolean => {
+  const { HOME, NPM_TOKEN } = process.env
+
+  const projectNpmrcPath = './.npmrc'
+  const userNpmrcPath = `${HOME!}/.npmrc`
+
+  if (fs.existsSync(projectNpmrcPath)) {
+    console.log('Found existing .npmrc file in project directory')
+  } else if (fs.existsSync(userNpmrcPath)) {
+    console.log('Found existing .npmrc file in home directory')
+  } else if (NPM_TOKEN) {
+    console.log('No .npmrc file found, creating one')
+    fs.writeFileSync(
+      projectNpmrcPath,
+      `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`,
+    )
+  } else {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
Proposed changes:
1. Check project directory for `.npmrc` first
2. Use project directory as default location for creating one if none found

---

NPM prioritises project-level `.npmrc` above the config defined at the user level (see [here](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc#files)).

Current behaviour does not check the project directory for an `.npmrc` so our release stage fails in CI, despite having a valid `.npmrc` file pointing to a private GitLab registry.

If no `.npmrc` is found, creating one in the project repo feels safer than creating one in home—the change is obvious, explicit and scoped to the project rather than the user.