### PR TITLE
Repair default value for create_gitlab_releases variable

### DIFF
--- a/.changeset/thick-eyes-wave.md
+++ b/.changeset/thick-eyes-wave.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+fix: repair default value for `create_gitlab_releases` variable

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,7 @@ export const main = async ({
       const result = await runPublish({
         script: publishScript,
         gitlabToken: GITLAB_TOKEN!,
-        createGitlabReleases: getInput('create_gitlab_releases') === 'true',
+        createGitlabReleases: getInput('create_gitlab_releases') !== 'false',
       })
 
       if (result.published) {


### PR DESCRIPTION
The readme states that `create_gitlab_releases` should default to `true` but by the current implementation this does doesn't work.

If `create_gitlab_releases` is not defined `getInput('create_gitlab_releases') === 'true'` will evaluate to `false`, which means that the fallback defined in `runPublish` is not used.

This PR aims to fix that.