### PR TITLE
fix: git setup user name should use GITLAB_CI_USER_NAME

### DIFF
--- a/.changeset/brave-zebras-attend.md
+++ b/.changeset/brave-zebras-attend.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+fix: git setup user name should use GITLAB_CI_USER_NAME

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -3,7 +3,11 @@ import { exec } from '@actions/exec'
 import { execWithOutput, identify } from './utils.js'
 
 export const setupUser = async () => {
-  await exec('git', ['config', 'user.name', process.env.GITLAB_USER_NAME!])
+  await exec('git', [
+    'config',
+    'user.name',
+    process.env.GITLAB_CI_USER_NAME! || process.env.GITLAB_USER_NAME!,
+  ])
   await exec('git', [
     'config',
     'user.email',

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -6,7 +6,7 @@ export const setupUser = async () => {
   await exec('git', [
     'config',
     'user.name',
-    process.env.GITLAB_CI_USER_NAME! || process.env.GITLAB_USER_NAME!,
+    process.env.GITLAB_CI_USER_NAME || process.env.GITLAB_USER_NAME!,
   ])
   await exec('git', [
     'config',


### PR DESCRIPTION
Raising this PR as I found a bug in the git setup when setting user name.

As mentioned in the [README.md](/un-ts/changesets-gitlab/blob/main/README.md), you should be able to set git user name by specifying variable `GITLAB_CI_USER_NAME`. But the current code gets the user name from `GITLAB_USER_NAME` instead, which is a predefined Gitlab variable. Thus, setting variable `GITLAB_CI_USER_NAME` actually does nothing.

This PR fixes the issue by changing the code to use `GITLAB_CI_USER_NAME` instead for the git user name.