### PR TITLE
feat: add `GITLAB_COMMENT_TYPE` env variable to use discussions or notes

### DIFF
--- a/.changeset/thin-foxes-serve.md
+++ b/.changeset/thin-foxes-serve.md
@@ -2,4 +2,4 @@
 'changesets-gitlab': minor
 ---
 
-feat: add new COMMENT_TYPE environment variable to use discussions or notes
+feat: add new `GITLAB_COMMENT_TYPE` environment variable to use discussions or notes

--- a/.changeset/thin-foxes-serve.md
+++ b/.changeset/thin-foxes-serve.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+feat: add new COMMENT_TYPE environment variable to use discussions or notes

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ GITLAB_TOKEN            # required, token with accessibility to push
 GITLAB_TOKEN_TYPE       # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
 GITLAB_CI_USER_NAME     # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
 GITLAB_CI_USER_EMAIL    # optional, default `gitlab[bot]@users.noreply.gitlab.com`
+COMMENT_TYPE            # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
 DEBUG_GITLAB_CREDENTIAL # optional, default `false`
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ GITLAB_TOKEN            # required, token with accessibility to push
 GITLAB_TOKEN_TYPE       # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
 GITLAB_CI_USER_NAME     # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
 GITLAB_CI_USER_EMAIL    # optional, default `gitlab[bot]@users.noreply.gitlab.com`
-COMMENT_TYPE            # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
+GITLAB_COMMENT_TYPE     # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
 DEBUG_GITLAB_CREDENTIAL # optional, default `false`
 ```
 

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -172,7 +172,7 @@ export const comment = async () => {
     CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: mrBranch,
     CI_MERGE_REQUEST_SOURCE_BRANCH_SHA,
     CI_MERGE_REQUEST_TITLE,
-    COMMENT_TYPE = 'discussion',
+    GITLAB_COMMENT_TYPE = 'discussion',
   } = process.env
 
   if (!mrBranch) {
@@ -238,7 +238,7 @@ export const comment = async () => {
 
     const { editComment, createComment } = getCommentFunctions(
       api,
-      COMMENT_TYPE,
+      GITLAB_COMMENT_TYPE,
     )
 
     if (noteInfo != null) {


### PR DESCRIPTION
This PR adds a new `COMMENT_TYPE` environment variable, to control the type of comment created when using `changesets-gitlab comment`:
- `discussion` creates a new discussion ([thread](https://docs.gitlab.com/ee/api/discussions.html#create-new-merge-request-thread)). This is the default
- `note` creates a note ([comment](https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note))

This is useful when a GitLab repo requires all threads to be resolved before merging an MR. We can instead use this new `note` `COMMENT_TYPE` which won't block merging.