### PR TITLE
fix: editing comment when `GITLAB_COMMENT_TYPE` is note

### DIFF
--- a/.changeset/lovely-penguins-tease.md
+++ b/.changeset/lovely-penguins-tease.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+fix: editing comment when GITLAB_COMMENT_TYPE is note


### PR DESCRIPTION
Fix a bug introduced by https://github.com/un-ts/changesets-gitlab/pull/98

When `GITLAB_COMMENT_TYPE` is note and we have already created the note, it fails to update it with the following error: "note_id is invalid".

This was caused by `MergeRequestDiscussions.editNote` & `MergeRequestNotes.note` not having the same signature. The former takes both the discussion id and note id, but the latter only takes the note id.