### PR TITLE
feat: expose published outputs as env variables

### DIFF
--- a/.changeset/eleven-geese-rest.md
+++ b/.changeset/eleven-geese-rest.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+expose published outputs as env variables to be accessed dicrectly in `PUBLISHED` command process

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { URL } from 'node:url'
 
-import { getInput, setFailed, setOutput } from '@actions/core'
+import { getInput, setFailed, setOutput, exportVariable } from '@actions/core'
 import { exec } from '@actions/exec'
 import fs from 'fs-extra'
 
@@ -95,6 +95,8 @@ MainCommandOptions = {}) => {
       if (result.published) {
         setOutput('published', true)
         setOutput('publishedPackages', result.publishedPackages)
+        exportVariable('PUBLISHED', true)
+        exportVariable('PUBLISHED_PACKAGES', result.publishedPackages)
         if (published) {
           execSync(published)
         }


### PR DESCRIPTION
By far it seems the outputs are not accessible in Gitlab CI after changeset published, if I didn't miss something...I actually get them from `stdout` these days.
This PR aims to make published outputs available in `process.env`.