### PR TITLE
fix: add the path to the origin url

### DIFF
--- a/.changeset/three-eels-boil.md
+++ b/.changeset/three-eels-boil.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+Fix issue when the release MRs could not be created when gitlab is not hosted at the root of the of the domain (https://www.company.com/gitlab).

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ MainCommandOptions = {}) => {
         'origin',
         `${url.protocol}//${username}:${GITLAB_TOKEN!}@${
           url.host
-        }/${CI_PROJECT_PATH!}.git`,
+        }${url.pathname.replace(/\/$/, '')}/${CI_PROJECT_PATH!}.git`,
       ],
       { silent: !['true', '1'].includes(DEBUG_GITLAB_CREDENTIAL) },
     )


### PR DESCRIPTION
When gitlab is hosted in a nested path (e.g. http://www.company.com/gitlab) the release MR creation would fail because it would try and fetch the repo without the path (/gitlab) in the origin URL.

This MR adds the path to the origin url.