### PR TITLE
fix: deprecation warning in the `comment` command

### DIFF
--- a/.changeset/five-ravens-worry.md
+++ b/.changeset/five-ravens-worry.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": patch
+---
+
+fix: deprecation warning in the `comment` command


### PR DESCRIPTION
## Description

Fix the deprecation warning of using the `showChanges` API from `@gitbeaker/rest`.

## Current Behavior

```
$ pnpm changesets-gitlab comment
DeprecationWarning: This endpoint was deprecated in Gitlab API 15.7 and will be removed in API v5. Please use the "allDiffs" function instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

## Expected Behavior

No warning was emitted.

## Additional Information

I changed the type of the argument in the `hasChangesetBeenAdded` function from the inferred type

```typescript
ReturnType<MergeRequests['allDiffs']>
```

to the concrete type

```typescript
Promise<MergeRequestDiffSchema[]>
```

because I think checking something we don't really use (paginated or not) does not make a lot of sense.