### PR TITLE
fix: Gitlab Host Fallbacks

### DIFF
--- a/.changeset/little-geese-rule.md
+++ b/.changeset/little-geese-rule.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+fix: gitlab host fallback environment variables

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,7 +11,10 @@ export const env = {
   ...process.env,
 
   CI_MERGE_REQUEST_IID: +process.env.CI_MERGE_REQUEST_IID!,
-  GITLAB_HOST: process.env.GITLAB_HOST ?? process.env.CI_SERVER_URL ?? 'https://gitlab.com',
+  GITLAB_HOST:
+    process.env.GITLAB_HOST ??
+    process.env.CI_SERVER_URL ??
+    'https://gitlab.com',
   GITLAB_CI_USER_EMAIL:
     process.env.GITLAB_CI_USER_EMAIL || 'gitlab[bot]@users.noreply.gitlab.com',
   GITLAB_COMMENT_TYPE: process.env.GITLAB_COMMENT_TYPE ?? 'discussion',

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,11 +11,11 @@ export const env = {
   ...process.env,
 
   CI_MERGE_REQUEST_IID: +process.env.CI_MERGE_REQUEST_IID!,
+  GITLAB_HOST: process.env.GITLAB_HOST ?? process.env.CI_SERVER_URL ?? 'https://gitlab.com',
   GITLAB_CI_USER_EMAIL:
     process.env.GITLAB_CI_USER_EMAIL || 'gitlab[bot]@users.noreply.gitlab.com',
   GITLAB_COMMENT_TYPE: process.env.GITLAB_COMMENT_TYPE ?? 'discussion',
   DEBUG_GITLAB_CREDENTIAL: process.env.DEBUG_GITLAB_CREDENTIAL ?? 'false',
-  GITLAB_HOST: process.env.GITLAB_HOST ?? process.env.CI_SERVER_URL ?? 'https://gitlab.com',
 
   // only check for the token if we are explicitly using it
   // eslint-disable-next-line sonar/function-name

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,7 @@ export const env = {
     process.env.GITLAB_CI_USER_EMAIL || 'gitlab[bot]@users.noreply.gitlab.com',
   GITLAB_COMMENT_TYPE: process.env.GITLAB_COMMENT_TYPE ?? 'discussion',
   DEBUG_GITLAB_CREDENTIAL: process.env.DEBUG_GITLAB_CREDENTIAL ?? 'false',
+  GITLAB_HOST: process.env.GITLAB_HOST ?? process.env.CI_SERVER_URL ?? 'https://gitlab.com',
 
   // only check for the token if we are explicitly using it
   // eslint-disable-next-line sonar/function-name


### PR DESCRIPTION
v0.11.1 introduced a bug with gitlab host fallbacks, when environment variables were moved to their own module. This change reintroduces the gitlab host fallbacks.

Without this, I receive 401s when I use Gitlab CI with the `changesets-gitlab` CLI.

Fixes #146 