### PR TITLE
fix: don't fail if .npmrc exists in project root

### DIFF
--- a/.changeset/ten-dolphins-lick.md
+++ b/.changeset/ten-dolphins-lick.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': patch
+---
+
+allow .npmrc file to exist in project root

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,13 +68,14 @@ export const main = async ({
         'No changesets found, attempting to publish any unpublished packages to npm',
       )
 
-      const npmrcPath = `${HOME}/.npmrc`
-      if (fs.existsSync(npmrcPath)) {
+      const npmrcHome = `${HOME}/.npmrc`
+      const npmrcProject = `${CI_PROJECT_DIR}/.npmrc`
+      if (fs.existsSync(npmrcHome) || fs.existsSync(npmrcProject)) {
         console.log('Found existing .npmrc file')
       } else if (NPM_TOKEN) {
         console.log('No .npmrc file found, creating one')
         fs.writeFileSync(
-          npmrcPath,
+          npmrcHome,
           `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`,
         )
       } else {


### PR DESCRIPTION
Currently, `changesets-gitlab` will only check the the `${HOME}/.npmrc` path, or use the NPM_TOKEN variable assuming its for the public npm registry. While it's showed in the example in the README, it's not explicitly mentioned.

A common pattern used in [GitLab CI/CD examples](https://docs.gitlab.com/ee/user/packages/npm_registry/#publishing-a-package-by-using-a-cicd-pipeline), is to append auth to the project roots `.npmrc` file. When I set up the pipeline like I normally would, I was surprised to see it output that no .npmrc file was found. I'd imagine someone migrating from an old setup or following what they know from multiple guides could run into this as well.