### PR TITLE
feat: add PREFER_PROJECT_LEVEL_NPMRC

### DIFF
--- a/.changeset/dirty-ducks-relax.md
+++ b/.changeset/dirty-ducks-relax.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+Add support for `PREFER_PROJECT_LEVEL_NPMRC` variable checking the project root rather than `$HOME` for a `.npmrc` file when validating auth

--- a/README.md
+++ b/README.md
@@ -101,13 +101,16 @@ There's two ways you can authenticate with the GitLab CI cli.
   - Alternatively the project root `.npmrc` by setting `PREFER_PROJECT_LEVEL_NPMRC` to `true`
 - Setting `NPM_TOKEN` in [custom CI/CD variables](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) (only works with the public registry `registry.npmjs.org`)
 
-If you're using the public npm registry, you'll need to have an [npm token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) that can publish the packages in the repo you're setting up the action for and doesn't have 2FA on publish enabled ([2FA on auth can be enabled](https://docs.npmjs.com/about-two-factor-authentication)). [add it as a custom environment variable on your GitLab repo](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) with the name `NPM_TOKEN`. The GitLab CI cli then creates a `.npmrc` file with the following content:
+If you're using the public npm registry, you'll need to have an [npm token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) that can publish the packages in the repo you're setting up the action for and doesn't have 2FA on publish enabled ([2FA on auth can be enabled](https://docs.npmjs.com/about-two-factor-authentication)).
+[Add it as a custom environment variable on your GitLab repo](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) with the name `NPM_TOKEN`.
+The GitLab CI cli then creates a `.npmrc` file with the following content:
 
 ```sh
 //registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}
 ```
 
-If `.npmrc` exists in `$HOME` (or in the project root with `PREFER_PROJECT_LEVEL_NPMRC` set to `true`), the GitLab CI cli does not touch the file. This is useful if you need to configure the `.npmrc` file on your own.
+If `.npmrc` exists in `$HOME` (or in the project root with `PREFER_PROJECT_LEVEL_NPMRC` set to `true`), the GitLab CI cli does not touch the file.
+This is useful if you need to configure the `.npmrc` file on your own.
 For example, you can add a step before running the Changesets GitLab CI cli:
 
 ```yml

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,14 @@ import { execSync, getOptionalInput, getUsername } from './utils.js'
 
 import { createApi } from './index.js'
 
+const getNpmrcPath = () => {
+  if (env.CI && env.PREFER_PROJECT_LEVEL_NPMRC) {
+    return `${env.CI_PROJECT_DIR}/.npmrc`
+  }
+
+  return `${env.HOME}/.npmrc`
+}
+
 export const main = async ({
   published,
   onlyChangesets,
@@ -21,7 +29,6 @@ export const main = async ({
     CI,
     GITLAB_HOST,
     GITLAB_TOKEN,
-    HOME,
     NPM_TOKEN,
     DEBUG_GITLAB_CREDENTIAL = 'false',
   } = env
@@ -68,7 +75,7 @@ export const main = async ({
         'No changesets found, attempting to publish any unpublished packages to npm',
       )
 
-      const npmrcPath = `${HOME}/.npmrc`
+      const npmrcPath = getNpmrcPath()
       if (fs.existsSync(npmrcPath)) {
         console.log('Found existing .npmrc file')
       } else if (NPM_TOKEN) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type Env = GitLabCIPredefinedVariables &
 
     HOME: string
     NPM_TOKEN?: string
+    PREFER_PROJECT_LEVEL_NPMRC?: string
   }
 
 type MergeRequestVariables =
@@ -44,10 +45,12 @@ type GitLabCIPredefinedVariables = { GITLAB_USER_NAME: string } & (
   | {
       // this is used to be checked if the current job is in a CI environment
       CI: undefined
+      CI_PROJECT_DIR: undefined
     }
   | {
       CI: 'true'
       CI_PROJECT_PATH: string
       CI_SERVER_URL: string
+      CI_PROJECT_DIR: string
     }
 )


### PR DESCRIPTION
Implements the `PREFER_PROJECT_LEVEL_NPMRC` suggested in https://github.com/un-ts/changesets-gitlab/pull/161#issuecomment-1918968523

I had to move the computation of `npmrcPath` to it's own function to avoid getting an error with the `sonar/cognitive-complexity` rule.

Also restructured the publishing docs a bit to try to clarify the available options valid with `changesets-gitlab`.