### PR TITLE
fix: remove job token

### DIFF
--- a/.changeset/gold-maps-decide.md
+++ b/.changeset/gold-maps-decide.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": patch
+---
+
+fix: remove job token

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ GLOBAL_AGENT_NO_PROXY    # Like above but for no proxied requests
 
 GITLAB_HOST # optional, if you're using custom GitLab host, will fallback to `CI_SERVER_URL` if not provided
 
-GITLAB_TOKEN                 # required, token with accessibility to push
-GITLAB_TOKEN_TYPE            # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
+GITLAB_TOKEN                 # required, token with accessibility to push, package registries, and merge request APIs. Note the CI_JOB_TOKEN does not have sufficient permissons
+GITLAB_TOKEN_TYPE            # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. Can be `oauth` if you use Gitlab Oauth (personal access) token..
 GITLAB_CI_USER_NAME          # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
 GITLAB_CI_USER_EMAIL         # optional, default `gitlab[bot]@users.noreply.gitlab.com`
 GITLAB_COMMENT_TYPE          # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,26 +28,15 @@ export const createApi = (gitlabToken?: string) => {
   const token = gitlabToken || env.GITLAB_TOKEN
   const host = env.GITLAB_HOST
 
-  // we cannot use { [tokenType]: token } now
-  // because it will break the type of the Gitlab constructor
-  switch (env.GITLAB_TOKEN_TYPE) {
-    case 'job': {
-      return new Gitlab({
-        host,
-        jobToken: token,
-      })
-    }
-    case 'oauth': {
-      return new Gitlab({
-        host,
-        oauthToken: token,
-      })
-    }
-    default: {
-      return new Gitlab({
-        host,
-        token,
-      })
-    }
+  if (env.GITLAB_TOKEN_TYPE === 'oauth') {
+    return new Gitlab({
+      host,
+      oauthToken: token,
+    })
   }
+
+  return new Gitlab({
+    host,
+    token,
+  })
 }


### PR DESCRIPTION
Removes the job token from the API client.

Fixes #183 