### PR TITLE
fix: syntax error in README gitlab-ci example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,15 @@ before_script: yarn --frozen-lockfile
 comment:
   image: node:lts-alpine
   stage: comment
-  only: merge_requests
+  only: 
+    - merge_requests
   script: yarn changesets-gitlab comment # comment automatically like https://github.com/changesets/bot
 
 release:
   image: node:lts-alpine
-  only: main
+  stage: release
+  only: 
+    - main
   script: yarn changesets-gitlab
 ```
 
@@ -96,12 +99,15 @@ before_script: yarn --frozen-lockfile
 comment:
   image: node:lts-alpine
   stage: comment
-  only: merge_requests
+  only: 
+    - merge_requests
   script: yarn changesets-gitlab comment
 
 release:
   image: node:lts-alpine
-  only: main
+  stage: release
+  only: 
+    - main
   script: yarn changesets-gitlab
   variables:
     INPUT_PUBLISH: yarn release
@@ -146,7 +152,9 @@ comment:
 
 release:
   image: node:lts-alpine
-  only: main
+  stage: release
+  only: 
+    - main
   script: yarn changesets-gitlab
   variables:
     INPUT_VERSION: yarn version
@@ -172,7 +180,9 @@ comment:
 
 release:
   image: node:lts-alpine
-  only: main
+  stage: release
+  only: 
+    - main
   script: yarn changesets-gitlab
   variables:
     INPUT_VERSION: yarn changeset version
@@ -183,7 +193,8 @@ You may also want to run `yarn install` after the `changeset verion` command to 
 ```yml
 release:
   image: node:lts-alpine
-  only: main
+  only: 
+    - main
   script: yarn changesets-gitlab
   variables:
     YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ before_script: yarn --frozen-lockfile
 comment:
   image: node:lts-alpine
   stage: comment
-  only: 
+  only:
     - merge_requests
   script: yarn changesets-gitlab comment # comment automatically like https://github.com/changesets/bot
 
 release:
   image: node:lts-alpine
   stage: release
-  only: 
+  only:
     - main
   script: yarn changesets-gitlab
 ```
@@ -99,14 +99,14 @@ before_script: yarn --frozen-lockfile
 comment:
   image: node:lts-alpine
   stage: comment
-  only: 
+  only:
     - merge_requests
   script: yarn changesets-gitlab comment
 
 release:
   image: node:lts-alpine
   stage: release
-  only: 
+  only:
     - main
   script: yarn changesets-gitlab
   variables:
@@ -153,7 +153,7 @@ comment:
 release:
   image: node:lts-alpine
   stage: release
-  only: 
+  only:
     - main
   script: yarn changesets-gitlab
   variables:
@@ -181,7 +181,7 @@ comment:
 release:
   image: node:lts-alpine
   stage: release
-  only: 
+  only:
     - main
   script: yarn changesets-gitlab
   variables:
@@ -193,7 +193,7 @@ You may also want to run `yarn install` after the `changeset verion` command to 
 ```yml
 release:
   image: node:lts-alpine
-  only: 
+  only:
     - main
   script: yarn changesets-gitlab
   variables:


### PR DESCRIPTION
fix syntax error in README 
Fixes #185 