### PR TITLE
feat: allow to set different type of comment if changeset is missing

### DIFF
--- a/.changeset/plenty-badgers-bathe.md
+++ b/.changeset/plenty-badgers-bathe.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+Add configuration for comment if changeset is missing

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ GLOBAL_AGENT_NO_PROXY    # Like above but for no proxied requests
 
 GITLAB_HOST # optional, if you're using custom GitLab host, will fallback to `CI_SERVER_URL` if not provided
 
-GITLAB_TOKEN                 # required, token with accessibility to push
-GITLAB_TOKEN_TYPE            # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
-GITLAB_CI_USER_NAME          # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
-GITLAB_CI_USER_EMAIL         # optional, default `gitlab[bot]@users.noreply.gitlab.com`
-GITLAB_COMMENT_TYPE          # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
-GITLAB_ADD_CHANGESET_MESSAGE # optional, default commit message for adding changesets on GitLab Web UI
-DEBUG_GITLAB_CREDENTIAL      # optional, default `false`
+GITLAB_TOKEN                   # required, token with accessibility to push
+GITLAB_TOKEN_TYPE              # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
+GITLAB_CI_USER_NAME            # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
+GITLAB_CI_USER_EMAIL           # optional, default `gitlab[bot]@users.noreply.gitlab.com`
+GITLAB_COMMENT_TYPE            # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
+GITLAB_COMMENT_TYPE_IF_MISSING # optional, type of the comment when changeset is missing, default set to `GITLAB_COMMENT_TYPE`, should be `note` or `discussion`
+GITLAB_ADD_CHANGESET_MESSAGE   # optional, default commit message for adding changesets on GitLab Web UI
+DEBUG_GITLAB_CREDENTIAL        # optional, default `false`
 ```
 
 ### Example workflow

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -251,8 +251,11 @@ export const comment = async () => {
     CI_MERGE_REQUEST_SOURCE_BRANCH_SHA,
     CI_MERGE_REQUEST_TITLE,
     GITLAB_COMMENT_TYPE,
+    GITLAB_COMMENT_TYPE_IF_MISSING,
     GITLAB_ADD_CHANGESET_MESSAGE,
   } = env
+
+  let comment_type = GITLAB_COMMENT_TYPE
 
   if (mrBranch.startsWith('changeset-release')) {
     return
@@ -311,7 +314,10 @@ export const comment = async () => {
         : getAbsentMessage(latestCommitSha, addChangesetUrl, releasePlan)) +
       errFromFetchingChangedFiles
 
-    switch (GITLAB_COMMENT_TYPE) {
+    if (!hasChangeset) {
+      comment_type = GITLAB_COMMENT_TYPE_IF_MISSING
+    }
+    switch (comment_type) {
       case 'discussion': {
         if (noteInfo) {
           return api.MergeRequestDiscussions.editNote(
@@ -345,7 +351,7 @@ export const comment = async () => {
       }
       default: {
         throw new Error(
-          `Invalid comment type "${GITLAB_COMMENT_TYPE}", should be "discussion" or "note"`,
+          `Invalid comment type "${comment_type}", should be "discussion" or "note"`,
         )
       }
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,7 +7,7 @@ dotenv.config()
 
 let isGitlabTokenValidated = false
 
-export const env = {
+const env = {
   ...process.env,
 
   CI_MERGE_REQUEST_IID: +process.env.CI_MERGE_REQUEST_IID!,
@@ -32,3 +32,8 @@ export const env = {
     return process.env.GITLAB_TOKEN!
   },
 } as Env
+
+env.GITLAB_COMMENT_TYPE_IF_MISSING =
+  process.env.GITLAB_COMMENT_TYPE_IF_MISSING ?? env.GITLAB_COMMENT_TYPE
+
+export { env }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type Env = GitLabCIPredefinedVariables &
     GITLAB_CI_USER_NAME?: string
     GITLAB_CI_USER_EMAIL: string
     GITLAB_COMMENT_TYPE: LooseString<'discussion' | 'note'>
+    GITLAB_COMMENT_TYPE_IF_MISSING: LooseString<'discussion' | 'note'>
     GITLAB_ADD_CHANGESET_MESSAGE?: string
     DEBUG_GITLAB_CREDENTIAL: LooseString<'1' | 'true'>
 


### PR DESCRIPTION
Add a parameter (`GITLAB_COMMENT_TYPE_IF_MISSING`) to set a specific type of comment when changeset is missing.


Closes: #190