### PR TITLE
feat: update labels on update merge request

### DIFF
--- a/.changeset/green-phones-wave.md
+++ b/.changeset/green-phones-wave.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+feat: update labels on update merge request

--- a/.changeset/green-phones-wave.md
+++ b/.changeset/green-phones-wave.md
@@ -1,5 +1,5 @@
 ---
-'changesets-gitlab': minor
+'changesets-gitlab': patch
 ---
 
 feat: update labels on update merge request

--- a/src/run.ts
+++ b/src/run.ts
@@ -216,6 +216,10 @@ export async function runVersion({
   await exec('git', ['fetch', 'origin', currentBranch])
   await gitUtils.reset(`origin/${currentBranch}`)
 
+  const labels = getOptionalInput('labels')
+    ?.split(',')
+    .map(x => x.trim())
+
   const versionsByDirectory = await getVersionsByDirectory(cwd)
 
   if (script) {
@@ -313,9 +317,7 @@ ${
       {
         description: await mrBodyPromise,
         removeSourceBranch,
-        labels: getOptionalInput('labels')
-          ?.split(',')
-          .map(x => x.trim()),
+        labels,
       },
     )
   } else {
@@ -324,9 +326,7 @@ ${
       title: finalMrTitle,
       description: await mrBodyPromise,
       removeSourceBranch,
-      labels: getOptionalInput('labels')
-        ?.split(',')
-        .map(x => x.trim()),
+      labels,
     })
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -324,6 +324,9 @@ ${
       title: finalMrTitle,
       description: await mrBodyPromise,
       removeSourceBranch,
+      labels: getOptionalInput('labels')
+        ?.split(',')
+        .map(x => x.trim()),
     })
   }
 }


### PR DESCRIPTION
Hello,

I am working with your tool and I want to update a merge request with labels but this feature is not available today, only at the creation.
This merge request aims to fix this.
It follows this work: https://github.com/un-ts/changesets-gitlab/pull/180/files

Thanks for your work!
