### PR TITLE
feat: fetch the tags and push each one individually

### DIFF
--- a/.changeset/mighty-chefs-serve.md
+++ b/.changeset/mighty-chefs-serve.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+fetch the tags and push each one individually

--- a/.changeset/mighty-chefs-serve.md
+++ b/.changeset/mighty-chefs-serve.md
@@ -1,5 +1,5 @@
 ---
-'changesets-gitlab': minor
+"changesets-gitlab": minor
 ---
 
-fetch the tags and push each one individually
+feat: fetch the tags and push each one individually

--- a/.changeset/mighty-chefs-serve.md
+++ b/.changeset/mighty-chefs-serve.md
@@ -2,4 +2,4 @@
 "changesets-gitlab": minor
 ---
 
-feat: fetch the tags and push each one individually
+feat: fetch the tags and push each one individually based on size of `packages` to be published and `api.FeatureFlags(projectId, 'git_push_create_all_pipelines')`

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Build
         run: yarn build
 
-      - run: yarn dlx pkg-pr-new publish
+      - run: yarn dlx pkg-pr-new publish --compact

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ GitLab CI cli for [changesets](https://github.com/atlassian/changesets) like its
 - `INPUT_TARGET_BRANCH` -> The merge request target branch. Defaults to current branch
 - `INPUT_CREATE_GITLAB_RELEASES` - A boolean value to indicate whether to create Gitlab releases after publish or not. Default true.
 - `INPUT_LABELS` - A comma separated string of labels to be added to the version package Gitlab Merge request
+- `INPUT_PUSH_ALL_TAGS` - A boolean value to indicate whether to push all tags at once using `git push origin --tags` [see](https://github.com/un-ts/changesets-gitlab/issues/194). Default true.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GitLab CI cli for [changesets](https://github.com/atlassian/changesets) like its
 - `INPUT_TARGET_BRANCH` -> The merge request target branch. Defaults to current branch
 - `INPUT_CREATE_GITLAB_RELEASES` - A boolean value to indicate whether to create Gitlab releases after publish or not. Default true.
 - `INPUT_LABELS` - A comma separated string of labels to be added to the version package Gitlab Merge request
-- `INPUT_PUSH_ALL_TAGS` - A boolean value to indicate whether to push all tags at once using `git push origin --tags` [see](https://github.com/un-ts/changesets-gitlab/issues/194). Default true.
+- `INPUT_PUSH_ALL_TAGS` - A boolean value to indicate whether to push all tags at once using `git push origin --tags`, see [#194](https://github.com/un-ts/changesets-gitlab/issues/194) for details. Default true.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ GitLab CI cli for [changesets](https://github.com/atlassian/changesets) like its
 - `INPUT_TARGET_BRANCH` -> The merge request target branch. Defaults to current branch
 - `INPUT_CREATE_GITLAB_RELEASES` - A boolean value to indicate whether to create Gitlab releases after publish or not. Default true.
 - `INPUT_LABELS` - A comma separated string of labels to be added to the version package Gitlab Merge request
-- `INPUT_PUSH_ALL_TAGS` - A boolean value to indicate whether to push all tags at once using `git push origin --tags`, see [#194](https://github.com/un-ts/changesets-gitlab/issues/194) for details. Default true.
 
 ### Outputs
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "changesets-gitlab",
   "version": "0.12.2",
   "type": "module",
-  "repository": "https://github.com/rx-ts/changesets-gitlab.git",
+  "repository": "https://github.com/un-ts/changesets-gitlab.git",
   "author": "JounQin (https://www.1stG.me) <admin@1stg.me>",
   "funding": "https://opencollective.com/changesets-gitlab",
   "license": "MIT",

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,21 +27,26 @@ export const push = async (
 }
 
 export const pushTags = async () => {
+  // Get the commit hash
+  const { stdout: commitHash } = await execWithOutput("git", [
+    "rev-parse",
+    "HEAD",
+  ]);
   // Get the tags that contain the commit
-  const { stdout: tags } = await execWithOutput('git', [
-    '--no-pager',
-    'tag',
-    `HEAD`,
-  ])
+  const { stdout: tags } = await execWithOutput("git", [
+    "--no-pager",
+    "tag",
+    "--contains",
+    commitHash,
+  ]);
   // Separate the tags into a list
-  const tagList = tags.split('\n')
-  if (tagList.length > 0) {
-    // Push the tags individually to the remote
-    for (const tag of tagList) {
-      await exec('git', ['push', 'origin', tag])
-    }
+  const tagList = tags.split("\n");
+  // Push the tags individually to the remote
+  for (const tag of tagList) {
+    await exec("git", ["push", "origin", tag]);
   }
-}
+};
+
 
 export const switchToMaybeExistingBranch = async (branch: string) => {
   const { stderr } = await execWithOutput('git', ['checkout', branch], {

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,26 +27,19 @@ export const push = async (
 }
 
 export const pushTags = async () => {
-  // Get the commit hash
-  const { stdout: commitHash } = await execWithOutput("git", [
-    "rev-parse",
-    "HEAD",
-  ]);
   // Get the tags that contain the commit
-  const { stdout: tags } = await execWithOutput("git", [
-    "--no-pager",
-    "tag",
-    "--contains",
-    commitHash,
-  ]);
+  const { stdout: tags } = await execWithOutput('git', [
+    '--no-pager',
+    'tag',
+    `HEAD`,
+  ])
   // Separate the tags into a list
-  const tagList = tags.split("\n");
+  const tagList = tags.split('\n')
   // Push the tags individually to the remote
   for (const tag of tagList) {
-    await exec("git", ["push", "origin", tag]);
+    await exec('git', ['push', 'origin', tag])
   }
-};
-
+}
 
 export const switchToMaybeExistingBranch = async (branch: string) => {
   const { stderr } = await execWithOutput('git', ['checkout', branch], {

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,26 +27,13 @@ export const push = async (
 }
 
 export const pushTags = async () => {
-  // Get the commit hash
-  const { stdout: commitHash } = await execWithOutput("git", [
-    "rev-parse",
-    "HEAD",
-  ]);
-  // Get the tags that contain the commit
-  const { stdout: tags } = await execWithOutput("git", [
-    "--no-pager",
-    "tag",
-    "--contains",
-    commitHash,
-  ]);
-  // Separate the tags into a list
-  const tagList = tags.split("\n");
-  // Push the tags individually to the remote
-  for (const tag of tagList) {
-    await exec("git", ["push", "origin", tag]);
-  }
-};
+  await exec('git', ['push', 'origin', '--tags'])
+}
 
+export const pushTag = async (tag: string) => {
+  console.log('Pushing tag: ' + tag)
+  await exec('git', ['push', 'origin', tag])
+}
 
 export const switchToMaybeExistingBranch = async (branch: string) => {
   const { stderr } = await execWithOutput('git', ['checkout', branch], {

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,8 +27,26 @@ export const push = async (
 }
 
 export const pushTags = async () => {
-  await exec('git', ['push', 'origin', '--tags'])
-}
+  // Get the commit hash
+  const { stdout: commitHash } = await execWithOutput("git", [
+    "rev-parse",
+    "HEAD",
+  ]);
+  // Get the tags that contain the commit
+  const { stdout: tags } = await execWithOutput("git", [
+    "--no-pager",
+    "tag",
+    "--contains",
+    commitHash,
+  ]);
+  // Separate the tags into a list
+  const tagList = tags.split("\n");
+  // Push the tags individually to the remote
+  for (const tag of tagList) {
+    await exec("git", ["push", "origin", tag]);
+  }
+};
+
 
 export const switchToMaybeExistingBranch = async (branch: string) => {
   const { stderr } = await execWithOutput('git', ['checkout', branch], {

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -35,9 +35,11 @@ export const pushTags = async () => {
   ])
   // Separate the tags into a list
   const tagList = tags.split('\n')
-  // Push the tags individually to the remote
-  for (const tag of tagList) {
-    await exec('git', ['push', 'origin', tag])
+  if (tagList.length > 0) {
+    // Push the tags individually to the remote
+    for (const tag of tagList) {
+      await exec('git', ['push', 'origin', tag])
+    }
   }
 }
 

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -31,7 +31,6 @@ export const pushTags = async () => {
 }
 
 export const pushTag = async (tag: string) => {
-  console.log('Pushing tag: ' + tag)
   await exec('git', ['push', 'origin', tag])
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { runPublish, runVersion } from './run.js'
 import type { MainCommandOptions } from './types.js'
 import {
   execSync,
+  FALSY_VALUES,
   getOptionalInput,
   getUsername,
   TRUTHY_VALUES,
@@ -84,8 +85,10 @@ export const main = async ({
       const result = await runPublish({
         script: publishScript,
         gitlabToken: GITLAB_TOKEN,
-        createGitlabReleases: getInput('create_gitlab_releases') !== 'false',
-        pushAllTags: getInput('push_all_tags') !== 'false',
+        createGitlabReleases: !FALSY_VALUES.has(
+          getInput('create_gitlab_releases'),
+        ),
+        pushAllTags: !FALSY_VALUES.has(getInput('push_all_tags')),
       })
 
       if (result.published) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,7 @@ export const main = async ({
         script: publishScript,
         gitlabToken: GITLAB_TOKEN,
         createGitlabReleases: getInput('create_gitlab_releases') !== 'false',
+        pushAllTags: getInput('push_all_tags') !== 'false',
       })
 
       if (result.published) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,6 @@ export const main = async ({
         createGitlabReleases: !FALSY_VALUES.has(
           getInput('create_gitlab_releases'),
         ),
-        pushAllTags: !FALSY_VALUES.has(getInput('push_all_tags')),
       })
 
       if (result.published) {

--- a/src/read-changeset-state.ts
+++ b/src/read-changeset-state.ts
@@ -1,15 +1,11 @@
 import { readPreState } from '@changesets/pre'
-import _readChangesets from '@changesets/read'
+import readChangesets from '@changesets/read'
 import type { PreState, NewChangeset } from '@changesets/types'
 
 export interface ChangesetState {
   preState: PreState | undefined
   changesets: NewChangeset[]
 }
-
-// @ts-expect-error - workaround for https://github.com/atlassian/changesets/issues/622
-const readChangesets = (_readChangesets.default ||
-  _readChangesets) as typeof _readChangesets
 
 export default async function readChangesetState(
   cwd: string = process.cwd(),

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,6 +59,7 @@ interface PublishOptions {
   script: string
   gitlabToken: string
   createGitlabReleases?: boolean
+  pushAllTags?: boolean
   cwd?: string
 }
 
@@ -81,6 +82,7 @@ export async function runPublish({
   script,
   gitlabToken,
   createGitlabReleases = true,
+  pushAllTags = true,
   cwd = process.cwd(),
 }: PublishOptions): Promise<PublishResult> {
   const api = createApi(gitlabToken)
@@ -92,7 +94,9 @@ export async function runPublish({
     { cwd },
   )
 
-  await gitUtils.pushTags()
+  if (pushAllTags) {
+    await gitUtils.pushTags()
+  }
 
   const { packages, tool } = await getPackages(cwd)
   const releasedPackages: Package[] = []
@@ -112,6 +116,11 @@ export async function runPublish({
 
       if (match) {
         releasedPackages.push(pkg)
+        if (!pushAllTags) {
+          await gitUtils.pushTag(
+            `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+          )
+        }
         if (createGitlabReleases) {
           await createRelease(api, {
             pkg,
@@ -140,6 +149,13 @@ export async function runPublish({
         )
       }
       releasedPackages.push(pkg)
+    }
+    if (!pushAllTags) {
+      for (const pkg of releasedPackages) {
+        await gitUtils.pushTag(
+          `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+        )
+      }
     }
     if (createGitlabReleases) {
       await Promise.all(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,3 +175,5 @@ export const cjsRequire =
 export const FALSY_VALUES = new Set(['false', '0'])
 
 export const TRUTHY_VALUES = new Set(['true', '1'])
+
+export const GITLAB_MAX_TAGS = 4

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,4 +172,6 @@ export const getUsername = (api: Gitlab) => {
 export const cjsRequire =
   typeof require === 'undefined' ? createRequire(import.meta.url) : require
 
+export const FALSY_VALUES = new Set(['false', '0'])
+
 export const TRUTHY_VALUES = new Set(['true', '1'])


### PR DESCRIPTION
This is to bypass the [limitation of gitlab](https://docs.gitlab.com/ee/administration/instance_limits.html#number-of-pipelines-per-git-push) 


Fix #194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced release publishing: Tags are now pushed either individually or collectively based on release context.
	- Improved release creation by more robustly evaluating configuration inputs.
	- Updated publishing workflow to produce compact, clearer output.
	- New constants introduced for managing falsy values and GitLab tag limits.
- **Bug Fixes**
	- Resolved TypeScript import issues for better functionality in reading changesets.
- **Chores**
	- Updated repository URL in package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->