### PR TITLE
Add GITLAB_COMMENT_DISCUSSION_AUTORESOLVE optional environment

### DIFF
--- a/.changeset/swift-berries-exist.md
+++ b/.changeset/swift-berries-exist.md
@@ -1,0 +1,5 @@
+---
+'changesets-gitlab': minor
+---
+
+Add GITLAB_COMMENT_DISCUSSION_AUTORESOLVE optional environment variable to automaticly resolve added discussion with options to resolve discussion by default (value `all`) or resolve only when changeset is present (value `hasChangeset`)

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ GLOBAL_AGENT_NO_PROXY    # Like above but for no proxied requests
 
 GITLAB_HOST # optional, if you're using custom GitLab host, will fallback to `CI_SERVER_URL` if not provided
 
-GITLAB_TOKEN                 # required, token with accessibility to push
-GITLAB_TOKEN_TYPE            # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
-GITLAB_CI_USER_NAME          # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
-GITLAB_CI_USER_EMAIL         # optional, default `gitlab[bot]@users.noreply.gitlab.com`
-GITLAB_COMMENT_TYPE          # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
-GITLAB_ADD_CHANGESET_MESSAGE # optional, default commit message for adding changesets on GitLab Web UI
-DEBUG_GITLAB_CREDENTIAL      # optional, default `false`
+GITLAB_TOKEN                          # required, token with accessibility to push
+GITLAB_TOKEN_TYPE                     # optional, type of the provided token in GITLAB_TOKEN. defaults to personal access token. can be `job` if you provide the Gitlab CI_JOB_TOKEN or `oauth` if you use Gitlab Oauth token
+GITLAB_CI_USER_NAME                   # optional, username with accessibility to push, used in pairs of the above token (if it was personal access token). If not set read it from the Gitlab API
+GITLAB_CI_USER_EMAIL                  # optional, default `gitlab[bot]@users.noreply.gitlab.com`
+GITLAB_COMMENT_TYPE                   # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
+GITLAB_ADD_CHANGESET_MESSAGE          # optional, default commit message for adding changesets on GitLab Web UI
+GITLAB_COMMENT_DISCUSSION_AUTORESOLVE # optional, automaticly resolve added discussion with options to resolve discussion by default (value `all`) or resolve only when changeset is present (value `hasChangeset`)
+DEBUG_GITLAB_CREDENTIAL               # optional, default `false`
 ```
 
 ### Example workflow

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -251,6 +251,8 @@ export const comment = async () => {
     CI_MERGE_REQUEST_SOURCE_BRANCH_SHA,
     CI_MERGE_REQUEST_TITLE,
     GITLAB_COMMENT_TYPE,
+    GITLAB_COMMENT_DISCUSSION_AUTORESOLVE,
+    GITLAB_COMMENT_DISCUSSION_AUTORESOLVE_ONLY_CHANGESET_EXISTS,
     GITLAB_ADD_CHANGESET_MESSAGE,
   } = env
 
@@ -321,6 +323,7 @@ export const comment = async () => {
             noteInfo.noteId,
             {
               body: prComment,
+              resolved: GITLAB_COMMENT_DISCUSSION_AUTORESOLVE === 'always' || (GITLAB_COMMENT_DISCUSSION_AUTORESOLVE === 'hasChangeset' && hasChangeset),
             },
           )
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type Env = GitLabCIPredefinedVariables &
     GITLAB_CI_USER_NAME?: string
     GITLAB_CI_USER_EMAIL: string
     GITLAB_COMMENT_TYPE: LooseString<'discussion' | 'note'>
+    GITLAB_COMMENT_DISCUSSION_AUTORESOLVE: LooseString<'always' | 'hasChangeset'>
     GITLAB_ADD_CHANGESET_MESSAGE?: string
     DEBUG_GITLAB_CREDENTIAL: LooseString<'1' | 'true'>
 


### PR DESCRIPTION
This PR adds GITLAB_COMMENT_DISCUSSION_AUTORESOLVE optional environment variable to automaticly resolve added discussion with options to resolve discussion by default (value `all`) or resolve only when changeset is present (value `hasChangeset`).

This feature should help in projects where ability to merge depends on all resolved discussions. After little internal research all developers appreciate the notification about missing changeset but also this unresolved discussion comment might by useless when changeset check is ok.

