### PR TITLE
feat: add a new optional `GITLAB_COMMENT_CUSTOM_LINKS` env

### DIFF
--- a/.changeset/short-queens-cover.md
+++ b/.changeset/short-queens-cover.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": minor
+---
+
+feat: add a new optional `GITLAB_COMMENT_CUSTOM_LINKS` environment variable to override the links content referenced in the cli bot comment

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ GITLAB_CI_USER_NAME                    # optional, username with accessibility t
 GITLAB_CI_USER_EMAIL                   # optional, default `gitlab[bot]@users.noreply.gitlab.com`
 GITLAB_COMMENT_TYPE                    # optional, type of the comment. defaults to `discussion`. can be set to `note` to not create a discussion instead of a thread
 GITLAB_COMMENT_DISCUSSION_AUTO_RESOLVE # optional, automatically resolve added discussion when changeset is present, if you want to always resolve the discussion, you should actually use `GITLAB_COMMENT_TYPE=note` instead, default `true`
+GITLAB_COMMENT_CUSTOM_LINKS            # optional, override the links content referenced in the cli bot comment
 GITLAB_ADD_CHANGESET_MESSAGE           # optional, default commit message for adding changesets on GitLab Web UI
 DEBUG_GITLAB_CREDENTIAL                # optional, whether to log when setting remote url with sensitive `token` displayed
 ```

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -76,9 +76,12 @@ Merging this MR will not cause a version bump for any packages. If these changes
 
 ${getReleasePlanMessage(releasePlan)}
 
-[Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md).
+${
+  env.GITLAB_COMMENT_CUSTOM_LINKS ||
+  `[Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
-[Click here if you're a maintainer who wants to add a changeset to this MR](${addChangesetUrl})
+[Click here if you're a maintainer who wants to add a changeset to this MR](${addChangesetUrl})`
+}
 
 __${generatedByBotNote}__
 `
@@ -95,9 +98,12 @@ Latest commit: ${commitSha}
 
 ${getReleasePlanMessage(releasePlan)}
 
-Not sure what this means? [Click here  to learn what changesets are](https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md).
+${
+  env.GITLAB_COMMENT_CUSTOM_LINKS ||
+  `Not sure what this means? [Click here to learn what changesets are](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
-[Click here if you're a maintainer who wants to add another changeset to this MR](${addChangesetUrl})
+[Click here if you're a maintainer who wants to add another changeset to this MR](${addChangesetUrl})`
+}
 
 __${generatedByBotNote}__
 `

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Env = GitLabCIPredefinedVariables &
     GITLAB_COMMENT_DISCUSSION_AUTO_RESOLVE?: LooseString<'1' | 'true'>
     GITLAB_ADD_CHANGESET_MESSAGE?: string
     DEBUG_GITLAB_CREDENTIAL?: LooseString<'1' | 'true'>
+    GITLAB_COMMENT_CUSTOM_LINKS?: string
 
     HOME: string
     NPM_TOKEN?: string


### PR DESCRIPTION
PR from `main` branch is anti-pattern, #189 is closed accidently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional environment variable that allows users to customize the links displayed in GitLab merge request comments, offering greater flexibility in the feedback provided.

- **Documentation**
  - Updated the documentation to detail the usage of the new configuration option for customizing comment links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->