### PR TITLE
fix(deps): upgrade @actions/core to remediate Undici vulnerabilities

### DIFF
--- a/.changeset/secure-undici-chain.md
+++ b/.changeset/secure-undici-chain.md
@@ -1,0 +1,6 @@
+---
+"changesets-gitlab": patch
+---
+
+Upgrade `@actions/core` to resolve security advisories in its Undici
+dependency.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typecov": "type-coverage"
   },
   "dependencies": {
-    "@actions/core": "^1.11.1",
+    "@actions/core": "^2.0.3",
     "@actions/exec": "^1.1.1",
     "@changesets/assemble-release-plan": "^6.0.6",
     "@changesets/config": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,13 +226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/core@npm:^1.11.1":
-  version: 1.11.1
-  resolution: "@actions/core@npm:1.11.1"
+"@actions/core@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@actions/core@npm:2.0.3"
   dependencies:
-    "@actions/exec": "npm:^1.1.1"
-    "@actions/http-client": "npm:^2.0.1"
-  checksum: 10c0/9aa30b397d8d0dbc74e69fe46b23fb105cab989beb420c57eacbfc51c6804abe8da0f46973ca9f639d532ea4c096d0f4d37da0223fbe94f304fa3c5f53537c30
+    "@actions/exec": "npm:^2.0.0"
+    "@actions/http-client": "npm:^3.0.2"
+  checksum: 10c0/aaee1cf8a43ef07549ef7959d66cce85ffc254e3ceb893735b463c73c042596825d5ada067fe513e276da7dc75e78cc4de971748249ace17df7e232fa8081f07
   languageName: node
   linkType: hard
 
@@ -245,13 +245,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/http-client@npm:^2.0.1":
-  version: 2.2.3
-  resolution: "@actions/http-client@npm:2.2.3"
+"@actions/exec@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@actions/exec@npm:2.0.0"
+  dependencies:
+    "@actions/io": "npm:^2.0.0"
+  checksum: 10c0/21c7d51e8bd457e39daced34df05ba2b20365b66f3b00e838fc109a3f774d95b12a2aeeb5736d8a1ff1e50bbbea60cb6fb40b550c92d2c2e3ed74b9d6bdfc18b
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@actions/http-client@npm:3.0.2"
   dependencies:
     tunnel: "npm:^0.0.6"
-    undici: "npm:^5.25.4"
-  checksum: 10c0/13141b66a42aa4afd8c50f7479e13a5cdb5084ccb3c73ec48894b8029743389a3d2bf8cdc18e23fb70cd33995740526dd308815613907571e897c3aa1e5eada6
+    undici: "npm:^6.23.0"
+  checksum: 10c0/b58eedef5a76d4341edf66cba5df3acb338e420ea1ab5223c3f5d0bf7f5cfaa56d5a5578f8a0b7a9ce50ccc06a0d2bb74aad4abf8bd7b5606b032bbe0b623c92
   languageName: node
   linkType: hard
 
@@ -259,6 +268,13 @@ __metadata:
   version: 1.1.3
   resolution: "@actions/io@npm:1.1.3"
   checksum: 10c0/5b8751918e5bf0bebd923ba917fb1c0e294401e7ff0037f32c92a4efa4215550df1f6633c63fd4efb2bdaae8711e69b9e36925857db1f38935ff62a5c92ec29e
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@actions/io@npm:2.0.0"
+  checksum: 10c0/b66170cbce7e19b9560f445ebbe0af2d031857efbe759020708745384d7a94b738dc09df2636e0c3049a9172c7b293d09f8a882bf5c25cc86bd19844cef61c41
   languageName: node
   linkType: hard
 
@@ -2539,13 +2555,6 @@ __metadata:
     "@eslint/core": "npm:^0.13.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/554847c8f2b6bfe0e634f317fc43d0b54771eea0015c4f844f75915fdb9e6170c830c004291bad57db949d61771732e459f36ed059f45cf750af223f77357c5c
-  languageName: node
-  linkType: hard
-
-"@fastify/busboy@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@fastify/busboy@npm:2.1.1"
-  checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
   languageName: node
   linkType: hard
 
@@ -5137,7 +5146,7 @@ __metadata:
   resolution: "changesets-gitlab@workspace:."
   dependencies:
     "@1stg/common-config": "npm:^13.0.1"
-    "@actions/core": "npm:^1.11.1"
+    "@actions/core": "npm:^2.0.3"
     "@actions/exec": "npm:^1.1.1"
     "@changesets/assemble-release-plan": "npm:^6.0.6"
     "@changesets/changelog-github": "npm:^0.5.1"
@@ -13380,12 +13389,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.25.4":
-  version: 5.29.0
-  resolution: "undici@npm:5.29.0"
-  dependencies:
-    "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
+"undici@npm:^6.23.0":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `@actions/core` from 1.x to 2.x
- update the Yarn lockfile so the transitive HTTP stack uses Undici 6.28.0
- add a patch changeset

## Why

`@actions/core@1.11.1` brings in `@actions/http-client@2.2.3`, which resolves to `undici@5.29.0`. That release is affected by current security advisories, including GHSA-vxpw-j846-p89q, GHSA-p88m-4jfj-68fv, GHSA-35p6-xmwp-9g52, and GHSA-g8m3-5g58-fq7m.

`@actions/core@2.0.3` moves the dependency chain to `@actions/http-client@3.0.2` and `undici@6.28.0`, remediating the advisories without a package-manager override.

Core 2 is used instead of Core 3 because Core 3 is ESM-only, while this package still exposes a CommonJS entry point.

## Validation

- `yarn --immutable`
- `PARSER_NO_WATCH=true yarn build`
- `PARSER_NO_WATCH=true yarn lint`
- `yarn test`
- verified `@actions/core@2.0.3` resolves through `@actions/http-client@3.0.2` to `undici@6.28.0`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitHub Actions utility to address security advisories affecting its networking dependency.
* **Chores**
  * Scheduled a patch release containing this security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->