### PR TITLE
fix: match changed packages by directory boundary

### DIFF
--- a/.changeset/quiet-cats-compare.md
+++ b/.changeset/quiet-cats-compare.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": patch
+---
+
+Fix changed package detection when one workspace directory prefixes another.

--- a/src/get-changed-packages.ts
+++ b/src/get-changed-packages.ts
@@ -21,6 +21,12 @@ function fetchFile(path: string) {
   return fs.readFile(path, 'utf8')
 }
 
+export const isFileInPackageDirectory = (
+  filePath: string,
+  packageDirectory: string,
+) =>
+  filePath === packageDirectory || filePath.startsWith(`${packageDirectory}/`)
+
 export const getChangedPackages = async ({
   changedFiles: changedFilesPromise,
 }: {
@@ -183,7 +189,9 @@ export const getChangedPackages = async ({
     changedPackages: (packages.tool === 'root'
       ? packages.packages
       : packages.packages.filter(pkg =>
-          changedFiles.some(changedFile => changedFile.includes(pkg.dir)),
+          changedFiles.some(changedFile =>
+            isFileInPackageDirectory(changedFile, pkg.dir),
+          ),
         )
     )
       .filter(

--- a/src/get-changed-packages.ts
+++ b/src/get-changed-packages.ts
@@ -21,12 +21,6 @@ function fetchFile(path: string) {
   return fs.readFile(path, 'utf8')
 }
 
-export const isFileInPackageDirectory = (
-  filePath: string,
-  packageDirectory: string,
-) =>
-  filePath === packageDirectory || filePath.startsWith(`${packageDirectory}/`)
-
 export const getChangedPackages = async ({
   changedFiles: changedFilesPromise,
 }: {
@@ -189,8 +183,9 @@ export const getChangedPackages = async ({
     changedPackages: (packages.tool === 'root'
       ? packages.packages
       : packages.packages.filter(pkg =>
-          changedFiles.some(changedFile =>
-            isFileInPackageDirectory(changedFile, pkg.dir),
+          changedFiles.some(
+            changedFile =>
+              changedFile === pkg.dir || changedFile.startsWith(`${pkg.dir}/`),
           ),
         )
     )

--- a/test/get-changed-packages.spec.ts
+++ b/test/get-changed-packages.spec.ts
@@ -1,27 +1,73 @@
-import { isFileInPackageDirectory } from '../src/get-changed-packages.js'
+const mocks = {
+  readFile: vi.fn(),
+  getAllFiles: vi.fn(),
+}
 
-describe('isFileInPackageDirectory', () => {
-  test('matches the package directory itself', () => {
-    expect(isFileInPackageDirectory('packages/ui-kit', 'packages/ui-kit')).toBe(
-      true,
-    )
+vi.doMock('node:fs/promises', () => ({ default: { readFile: mocks.readFile } }))
+vi.doMock('../src/utils.js', () => ({ getAllFiles: mocks.getAllFiles }))
+
+const { getChangedPackages } = await import('../src/get-changed-packages.js')
+
+const files = new Map([
+  ['package.json', JSON.stringify({ private: true })],
+  [
+    '.changeset/config.json',
+    JSON.stringify({
+      changelog: false,
+      commit: false,
+      fixed: [],
+      linked: [],
+      access: 'restricted',
+      baseBranch: 'main',
+      updateInternalDependencies: 'patch',
+      bumpVersionsWithWorkspaceProtocolOnly: false,
+      ignore: [],
+    }),
+  ],
+  ['pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n"],
+  [
+    'packages/ui-kit/package.json',
+    JSON.stringify({ name: '@example/ui-kit', version: '1.0.0' }),
+  ],
+  [
+    'packages/ui-kit-storybook/package.json',
+    JSON.stringify({ name: '@example/ui-kit-storybook', private: true }),
+  ],
+])
+
+beforeEach(() => {
+  mocks.getAllFiles.mockResolvedValue([
+    'package.json',
+    '.changeset/config.json',
+    'pnpm-workspace.yaml',
+    'packages/ui-kit/package.json',
+    'packages/ui-kit-storybook/package.json',
+  ])
+  mocks.readFile.mockImplementation((path: string) => {
+    const contents = files.get(path)
+    if (contents === undefined) {
+      throw new Error(`Unexpected path: ${path}`)
+    }
+    return Promise.resolve(contents)
+  })
+})
+
+describe('getChangedPackages', () => {
+  test('does not match sibling packages with the same prefix', async () => {
+    const result = await getChangedPackages({
+      changedFiles: ['packages/ui-kit-storybook/src/index.ts'],
+      api: undefined as never,
+    })
+
+    expect(result.changedPackages).toEqual([])
   })
 
-  test('matches files within the package directory', () => {
-    expect(
-      isFileInPackageDirectory(
-        'packages/ui-kit/src/index.ts',
-        'packages/ui-kit',
-      ),
-    ).toBe(true)
-  })
+  test('matches files within the package directory', async () => {
+    const result = await getChangedPackages({
+      changedFiles: ['packages/ui-kit/src/index.ts'],
+      api: undefined as never,
+    })
 
-  test('does not match sibling packages with the same prefix', () => {
-    expect(
-      isFileInPackageDirectory(
-        'packages/ui-kit-storybook/src/index.ts',
-        'packages/ui-kit',
-      ),
-    ).toBe(false)
+    expect(result.changedPackages).toEqual(['@example/ui-kit'])
   })
 })

--- a/test/get-changed-packages.spec.ts
+++ b/test/get-changed-packages.spec.ts
@@ -1,0 +1,21 @@
+import { isFileInPackageDirectory } from '../src/get-changed-packages.js'
+
+describe('isFileInPackageDirectory', () => {
+  test('matches files within the package directory', () => {
+    expect(
+      isFileInPackageDirectory(
+        'packages/ui-kit/src/index.ts',
+        'packages/ui-kit',
+      ),
+    ).toBe(true)
+  })
+
+  test('does not match sibling packages with the same prefix', () => {
+    expect(
+      isFileInPackageDirectory(
+        'packages/ui-kit-storybook/src/index.ts',
+        'packages/ui-kit',
+      ),
+    ).toBe(false)
+  })
+})

--- a/test/get-changed-packages.spec.ts
+++ b/test/get-changed-packages.spec.ts
@@ -1,6 +1,12 @@
 import { isFileInPackageDirectory } from '../src/get-changed-packages.js'
 
 describe('isFileInPackageDirectory', () => {
+  test('matches the package directory itself', () => {
+    expect(isFileInPackageDirectory('packages/ui-kit', 'packages/ui-kit')).toBe(
+      true,
+    )
+  })
+
   test('matches files within the package directory', () => {
     expect(
       isFileInPackageDirectory(


### PR DESCRIPTION
## Summary

- match changed files against complete package directory segments
- avoid false positives when one workspace name prefixes another, such as packages/ui-kit and packages/ui-kit-storybook
- add regression coverage for both nested files and prefix-collision siblings

## Tests

- yarn test
- yarn lint:tsc
- yarn eslint src/get-changed-packages.ts test/get-changed-packages.spec.ts
- yarn prettier --check src/get-changed-packages.ts test/get-changed-packages.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package change detection for workspace directories with shared name prefixes.
  - Prevented files from one package being incorrectly attributed to another package.
  - Ensured only files located within a package directory are associated with that package.

- **Tests**
  - Added coverage for files within package directories and similarly prefixed sibling directories.
  - Added validation for exact package-directory matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->