### PR TITLE
fix: support trusted publishing with optional NPM_TOKEN env

### DIFF
--- a/.changeset/yummy-hairs-enjoy.md
+++ b/.changeset/yummy-hairs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": minor
+---
+
+Add support for Trusted Publishers

--- a/.changeset/yummy-hairs-enjoy.md
+++ b/.changeset/yummy-hairs-enjoy.md
@@ -1,5 +1,5 @@
 ---
-"changesets-gitlab": minor
+"changesets-gitlab": patch
 ---
 
-Add support for Trusted Publishers
+fix: support trusted publishing with optional NPM_TOKEN env

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ release:
 
 There are two ways to authenticate with npm when publishing:
 
-1. Trusted Publishers (recommended): Configure npm Trusted Publishers for your GitLab pipeline (see the npm docs: https://docs.npmjs.com/trusted-publishers#supported-cicd-providers). When the pipeline runs, npm will inject an `NPM_ID_TOKEN`, which this tool detects. In this mode you do NOT need to set `NPM_TOKEN`, and no `.npmrc` file is required—the npm CLI exchanges the identity token automatically.
+1. Trusted Publishers (recommended): Configure npm Trusted Publishers for your GitLab pipeline (see the npm docs: <https://docs.npmjs.com/trusted-publishers#supported-cicd-providers>). When the pipeline runs, npm will inject an `NPM_ID_TOKEN`, which this tool detects. In this mode you do NOT need to set `NPM_TOKEN`, and no `.npmrc` file is required—the npm CLI exchanges the identity token automatically.
 2. Classic Automation Token: Create an [npm automation token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) (without 2FA on publish) and add it as a [custom environment variable in GitLab](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) named `NPM_TOKEN`.
 
 For any of the methods, create a file at `.gitlab-ci.yml` with the following content:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ release:
 
 #### With Publishing
 
-Before you can setup this action with publishing, you'll need to have an [npm token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) that can publish the packages in the repo you're setting up the action for and doesn't have 2FA on publish enabled ([2FA on auth can be enabled](https://docs.npmjs.com/about-two-factor-authentication)). You'll also need to [add it as a custom environment variable on your GitLab repo](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) with the name `NPM_TOKEN`. Once you've done that, you can create a file at `.gitlab-ci.yml` with the following content.
+There are two ways to authenticate with npm when publishing:
+
+1. Trusted Publishers (recommended): Configure npm Trusted Publishers for your GitLab pipeline (see the npm docs: https://docs.npmjs.com/trusted-publishers#supported-cicd-providers). When the pipeline runs, npm will inject an `NPM_ID_TOKEN`, which this tool detects. In this mode you do NOT need to set `NPM_TOKEN`, and no `.npmrc` file is required—the npm CLI exchanges the identity token automatically.
+2. Classic Automation Token: Create an [npm automation token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) (without 2FA on publish) and add it as a [custom environment variable in GitLab](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) named `NPM_TOKEN`.
+
+For any of the methods, create a file at `.gitlab-ci.yml` with the following content:
 
 ```yml
 stages:
@@ -114,13 +119,14 @@ release:
     INPUT_PUBLISH: yarn release
 ```
 
-By default the GitLab CI cli creates a `.npmrc` file with the following content:
+By default the GitLab CI cli creates a `.npmrc` file with the following content when `NPM_TOKEN` is present and no `.npmrc` exists (classic token mode):
 
 ```sh
 //registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}
 ```
 
 However, if a `.npmrc` file is found, the GitLab CI cli does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
+If `NPM_ID_TOKEN` is detected (Trusted Publishers), no `.npmrc` file is created or required.
 For example, you can add a step before running the Changesets GitLab CI cli:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ release:
 
 There are two ways to authenticate with npm when publishing:
 
-1. Trusted Publishers (recommended): Configure npm Trusted Publishers for your GitLab pipeline (see the npm docs: <https://docs.npmjs.com/trusted-publishers#supported-cicd-providers>). When the pipeline runs, npm will inject an `NPM_ID_TOKEN`, which this tool detects. In this mode you do NOT need to set `NPM_TOKEN`, and no `.npmrc` file is required—the npm CLI exchanges the identity token automatically.
+1. Trusted Publishers (recommended): Configure npm Trusted Publishers for your GitLab pipeline (see the npm docs: <https://docs.npmjs.com/trusted-publishers#supported-cicd-providers>). When the pipeline runs, npm will inject an `NPM_ID_TOKEN`, you do NOT need to set `NPM_TOKEN`, and no `.npmrc` file is required—the npm CLI exchanges the identity token automatically.
 2. Classic Automation Token: Create an [npm automation token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) (without 2FA on publish) and add it as a [custom environment variable in GitLab](https://docs.gitlab.com/ee/ci/variables/#custom-cicd-variables) named `NPM_TOKEN`.
 
 For any of the methods, create a file at `.gitlab-ci.yml` with the following content:
@@ -126,7 +126,6 @@ By default the GitLab CI cli creates a `.npmrc` file with the following content 
 ```
 
 However, if a `.npmrc` file is found, the GitLab CI cli does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
-If `NPM_ID_TOKEN` is detected (Trusted Publishers), no `.npmrc` file is created or required.
 For example, you can add a step before running the Changesets GitLab CI cli:
 
 ```yml

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import { URL } from 'node:url'
 
-import { getInput, setFailed, setOutput, exportVariable } from '@actions/core'
+import { exportVariable, getInput, setOutput } from '@actions/core'
 import { exec } from '@actions/exec'
 
 import { createApi } from './api.ts'
@@ -11,18 +11,20 @@ import readChangesetState from './read-changeset-state.js'
 import { runPublish, runVersion } from './run.js'
 import type { MainCommandOptions } from './types.js'
 import {
-  execSync,
   FALSY_VALUES,
+  TRUTHY_VALUES,
+  execSync,
+  fileExists,
   getOptionalInput,
   getUsername,
-  TRUTHY_VALUES,
 } from './utils.js'
 
 export const main = async ({
   published,
   onlyChangesets,
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 }: MainCommandOptions = {}) => {
-  const { GITLAB_TOKEN, NPM_TOKEN, NPM_ID_TOKEN } = env
+  const { GITLAB_TOKEN, NPM_TOKEN } = env
 
   setOutput('published', false)
   setOutput('publishedPackages', [])
@@ -66,25 +68,41 @@ export const main = async ({
         'No changesets found, attempting to publish any unpublished packages to npm',
       )
 
-      const npmrcPath = `${env.HOME}/.npmrc`
-      if (fs.existsSync(npmrcPath)) {
-        console.log('Found existing .npmrc file')
-      } else if (NPM_ID_TOKEN) {
-        // Using npm Trusted Publishers: npm will exchange the OIDC token for a publish token internally.
-        console.log(
-          'Detected `NPM_ID_TOKEN`; skipping `.npmrc` creation (Trusted Publishers mode).',
-        )
-      } else if (NPM_TOKEN) {
-        console.log('No .npmrc file found, creating one with `NPM_TOKEN`')
-        await fs.promises.writeFile(
-          npmrcPath,
-          `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`,
-        )
+      if (NPM_TOKEN) {
+        const userNpmrcPath = `${env.HOME}/.npmrc`
+        if (await fileExists(userNpmrcPath)) {
+          console.info('Found existing user .npmrc file')
+          const userNpmrcContent = await fs.readFile(userNpmrcPath, 'utf8')
+          const authLine = userNpmrcContent.split('\n').find(line => {
+            // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
+            return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line)
+          })
+          if (authLine) {
+            console.info(
+              'Found existing auth token for the npm registry in the user .npmrc file',
+            )
+          } else {
+            console.info(
+              "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one",
+            )
+            await fs.appendFile(
+              userNpmrcPath,
+              `\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
+            )
+          }
+        } else {
+          console.info(
+            'No user .npmrc file found, creating one with NPM_TOKEN used as auth token',
+          )
+          await fs.writeFile(
+            userNpmrcPath,
+            `//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
+          )
+        }
       } else {
-        setFailed(
-          'No `.npmrc` found and neither `NPM_TOKEN` nor `NPM_ID_TOKEN` provided, unable to publish packages',
+        console.info(
+          'No NPM_TOKEN found - assuming trusted publishing or npm is already authenticated',
         )
-        return
       }
 
       const result = await runPublish({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,9 @@ export type Env = GitLabCIPredefinedVariables &
 
     HOME: string
     NPM_TOKEN?: string
+    // Presence of NPM_ID_TOKEN indicates usage of npm Trusted Publishers;
+    // when set we don't require nor create an .npmrc with NPM_TOKEN.
+    NPM_ID_TOKEN?: string
   }
 
 type MergeRequestVariables =

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,6 @@ export type Env = GitLabCIPredefinedVariables &
 
     HOME: string
     NPM_TOKEN?: string
-    // Presence of NPM_ID_TOKEN indicates usage of npm Trusted Publishers;
-    // when set we don't require nor create an .npmrc with NPM_TOKEN.
-    NPM_ID_TOKEN?: string
   }
 
 type MergeRequestVariables =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { execSync as execSync_ } from 'node:child_process'
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
@@ -142,7 +142,7 @@ export const identify = <T>(
 > => !!_
 
 export async function getAllFiles(dir: string, base = dir): Promise<string[]> {
-  const direntList = await fs.promises.readdir(dir, { withFileTypes: true })
+  const direntList = await fs.readdir(dir, { withFileTypes: true })
   const files = await Promise.all(
     // eslint-disable-next-line sonarjs/function-return-type
     direntList.map(dirent => {
@@ -166,6 +166,13 @@ export const getUsername = (api: Gitlab) => {
   return (
     env.GITLAB_CI_USER_NAME ??
     api.Users.showCurrentUser().then(currentUser => currentUser.username)
+  )
+}
+
+export function fileExists(filePath: string) {
+  return fs.access(filePath, fs.constants.F_OK).then(
+    () => true,
+    () => false,
   )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for npm Trusted Publishers using `NPM_ID_TOKEN`.
  * Publishing now supports classic authentication with `NPM_TOKEN`.
  * Trusted Publisher workflows no longer require an `.npmrc` file.
  * Classic token publishing automatically uses or creates the required npm configuration.
  * Publishing can proceed with existing authentication when no token is provided.

* **Documentation**
  * Updated publishing guidance with setup instructions for both authentication options.
  * Added a minor release notice documenting Trusted Publisher support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->