### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/changesets-gitlab/security/code-scanning/13](https://github.com/un-ts/changesets-gitlab/security/code-scanning/13)

Add an explicit `permissions` block to `.github/workflows/size-limit.yml` at the workflow root (preferred here since there is one job and this documents default access clearly).  
Use least privilege needed for this workflow:

- `contents: read` to allow checkout/repository read operations.
- `pull-requests: write` because `andresz1/size-limit-action` typically posts/updates PR comments/status on pull requests.

This preserves existing functionality while constraining `GITHUB_TOKEN` access compared to implicit defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
