### PR TITLE
feat: add Changesets v3 support

### DIFF
--- a/.changeset/changesets-v3-support.md
+++ b/.changeset/changesets-v3-support.md
@@ -1,0 +1,5 @@
+---
+"changesets-gitlab": major
+---
+
+Add support for Changesets v3 by handling the new version command exit code (1 when no unreleased changesets), detecting published packages via the `CHANGESETS_OUTPUT` env var, and preventing empty release MRs when the version command produces no file changes.

--- a/.changeset/changesets-v3-support.md
+++ b/.changeset/changesets-v3-support.md
@@ -2,4 +2,17 @@
 "changesets-gitlab": major
 ---
 
-Add support for Changesets v3 by handling the new version command exit code (1 when no unreleased changesets), detecting published packages via the `CHANGESETS_OUTPUT` env var, and preventing empty release MRs when the version command produces no file changes.
+Drop support for Changesets v2 and Node < 22. Bump all `@changesets/*` dependencies to v3 and `@manypkg/get-packages` to v3.
+
+Breaking changes:
+
+- **Node engine requirement** bumped from `>=18.0.0` to `^22.11 || ^24 || >=26` to match Changesets v3
+- **`@changesets/*` dependencies** bumped to v3 versions, which are ESM-only
+- **`@manypkg/get-packages`** bumped to v3, changing the `Packages` and `Package` types (`tool` is now an object with `type` property, `root` renamed to `rootPackage`, `Package` now requires `relativeDir`)
+
+Bug fixes for Changesets v3 compatibility:
+
+- Handle the new `changeset version` exit code 1 when no unreleased changesets exist
+- Detect published packages via the `CHANGESETS_OUTPUT` env var (NDJSON format), falling back to stdout "New tag:" parsing for Changesets v2
+- Prevent creating empty release MRs when the version command produces no file changes — fall through to publish instead
+- Use `ignoreReturnCode: true` on version and publish commands since v3 may exit non-zero in valid scenarios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 18
-          - 20
           - 22
+          - 24
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "packageManager": "yarn@4.18.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^22.11 || ^24 || >=26"
   },
   "bin": "lib/cli.js",
   "main": "./lib/index.cjs",
@@ -64,14 +64,14 @@
   "dependencies": {
     "@actions/core": "^2.0.3",
     "@actions/exec": "^1.1.1",
-    "@changesets/assemble-release-plan": "^6.0.6",
-    "@changesets/config": "^3.1.1",
-    "@changesets/errors": "^0.2.0",
-    "@changesets/parse": "^0.4.1",
-    "@changesets/pre": "^2.0.2",
-    "@changesets/read": "^0.6.3",
+    "@changesets/assemble-release-plan": "^7.0.0",
+    "@changesets/config": "^4.0.0",
+    "@changesets/errors": "^1.0.0",
+    "@changesets/parse": "^1.0.0",
+    "@changesets/pre": "^3.0.0",
+    "@changesets/read": "^1.0.0",
     "@gitbeaker/rest": "^42.2.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^3.1.0",
     "commander": "^13.1.0",
     "dotenv": "^16.5.0",
     "global-agent": "^3.0.0",
@@ -89,8 +89,8 @@
   },
   "devDependencies": {
     "@1stg/common-config": "^13.0.1",
-    "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.0",
+    "@changesets/changelog-github": "^1.0.0",
+    "@changesets/cli": "^3.0.0",
     "@commitlint/cli": "^19.8.0",
     "@pkgr/rollup": "^6.0.3",
     "@types/global-agent": "^3.0.0",

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,4 +1,3 @@
-import { ExitError } from '@changesets/errors'
 import type {
   ComprehensiveRelease,
   ReleasePlan,
@@ -302,11 +301,7 @@ export const comment = async () => {
           changedFiles: packageChangedFiles,
           cwdPrefix,
         }).catch((err: unknown) => {
-          if (err instanceof ExitError) {
-            errFromFetchingChangedFiles = `<details><summary>💥 An error occurred when fetching the changed packages and changesets in this MR</summary>\n\n\`\`\`\n${err.message}\n\`\`\`\n\n</details>\n`
-          } else {
-            console.error(err)
-          }
+          errFromFetchingChangedFiles = `<details><summary>💥 An error occurred when fetching the changed packages and changesets in this MR</summary>\n\n\`\`\`\n${err instanceof Error ? err.message : String(err)}\n\`\`\`\n\n</details>\n`
           return {
             changedPackages: ['@fake-scope/fake-pkg'],
             releasePlan: null,

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from '@changesets/errors'
+import { ExitError } from '@changesets/errors'
 import type {
   ComprehensiveRelease,
   ReleasePlan,
@@ -302,7 +302,7 @@ export const comment = async () => {
           changedFiles: packageChangedFiles,
           cwdPrefix,
         }).catch((err: unknown) => {
-          if (err instanceof ValidationError) {
+          if (err instanceof ExitError) {
             errFromFetchingChangedFiles = `<details><summary>💥 An error occurred when fetching the changed packages and changesets in this MR</summary>\n\n\`\`\`\n${err.message}\n\`\`\`\n\n</details>\n`
           } else {
             console.error(err)

--- a/src/get-changed-packages.ts
+++ b/src/get-changed-packages.ts
@@ -1,16 +1,16 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import assembleReleasePlan from '@changesets/assemble-release-plan'
-import { parse as parseConfig } from '@changesets/config'
-import parseChangeset from '@changesets/parse'
+import { assembleReleasePlan } from '@changesets/assemble-release-plan'
+import { validateConfig as parseConfig } from '@changesets/config'
+import { parseChangesetFile as parseChangeset } from '@changesets/parse'
 import type {
   PackageJSON,
   PreState,
   NewChangeset,
   WrittenConfig,
 } from '@changesets/types'
-import type { Packages, Tool } from '@manypkg/get-packages'
+import type { Package, Packages, Tool } from '@manypkg/get-packages'
 import micromatch from 'micromatch'
 import { parse } from 'yaml'
 
@@ -50,13 +50,14 @@ export const getChangedPackages = async ({
     }
   }
 
-  async function getPackage(pkgPath: string) {
+  async function getPackage(pkgPath: string): Promise<Package> {
     const jsonContent = await fetchJsonFile<PackageJSON>(
       `${pkgPath}/package.json`,
     )
     return {
       packageJson: jsonContent,
       dir: pkgPath,
+      relativeDir: pkgPath,
     }
   }
 
@@ -109,11 +110,11 @@ export const getChangedPackages = async ({
       )
     }
   }
-  let tool: { tool: Tool; globs: string[] } | undefined
+  let tool: { toolType: string; globs: string[] } | undefined
 
   if (isPnpm) {
     tool = {
-      tool: 'pnpm',
+      toolType: 'pnpm',
       globs: (
         parse(await fetchTextFile('pnpm-workspace.yaml')) as {
           packages: string[]
@@ -125,14 +126,14 @@ export const getChangedPackages = async ({
 
     if (rootPackageJsonContent.workspaces) {
       tool = {
-        tool: 'yarn',
+        toolType: 'yarn',
         globs: Array.isArray(rootPackageJsonContent.workspaces)
           ? rootPackageJsonContent.workspaces
           : rootPackageJsonContent.workspaces.packages,
       }
     } else if (rootPackageJsonContent.bolt?.workspaces) {
       tool = {
-        tool: 'bolt',
+        toolType: 'bolt',
         globs: rootPackageJsonContent.bolt.workspaces,
       }
     }
@@ -140,12 +141,16 @@ export const getChangedPackages = async ({
 
   const rootPackageJsonContent = await rootPackageJsonContentsPromise
 
+  const rootPackage: Package = {
+    dir: '/',
+    relativeDir: '.',
+    packageJson: rootPackageJsonContent,
+  }
+
   const packages: Packages = {
-    root: {
-      dir: '/',
-      packageJson: rootPackageJsonContent,
-    },
-    tool: tool ? tool.tool : 'root',
+    rootDir: '/',
+    rootPackage,
+    tool: { type: tool ? tool.toolType : 'root' } as Tool,
     packages: [],
   }
 
@@ -160,16 +165,22 @@ export const getChangedPackages = async ({
     const matches = micromatch(potentialWorkspaceDirectories, tool.globs)
     packages.packages = await Promise.all(matches.map(dir => getPackage(dir)))
   } else {
-    packages.packages.push(packages.root)
+    packages.packages.push(rootPackage)
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- https://github.com/microsoft/TypeScript/issues/9998
   if (hasErrored) {
     throw new Error('an error occurred when fetching files')
   }
 
-  const config = await configPromise.then(rawConfig =>
-    parseConfig(rawConfig, packages),
-  )
+  const config = await configPromise.then(rawConfig => {
+    const result = parseConfig(rawConfig, packages)
+    if (result.errors) {
+      throw new Error(
+        `Failed to parse changeset config: ${result.errors.join(', ')}`,
+      )
+    }
+    return result.config
+  })
 
   const releasePlan = assembleReleasePlan(
     await Promise.all(changesetPromises),
@@ -179,7 +190,7 @@ export const getChangedPackages = async ({
   )
 
   return {
-    changedPackages: (packages.tool === 'root'
+    changedPackages: (packages.tool.type === 'root'
       ? packages.packages
       : packages.packages.filter(pkg =>
           changedFiles.some(

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,9 +27,14 @@ export const push = async (
 }
 
 export const pushTags = async () => {
-  await exec('git', ['push', 'origin', '--tags'], {
-    ignoreReturnCode: true,
-  })
+  const { stderr, code } = await execWithOutput(
+    'git',
+    ['push', 'origin', '--tags'],
+    { ignoreReturnCode: true },
+  )
+  if (code !== 0 && !stderr.includes('already exists')) {
+    throw new Error(`Failed to push tags: ${stderr}`)
+  }
 }
 
 export const pushTag = async (tag: string) => {
@@ -37,15 +42,22 @@ export const pushTag = async (tag: string) => {
   // In Changesets v3, the git-tag command may report tags that were
   // "skipped (already exist)" on the remote but don't exist locally,
   // causing `git push origin <tag>` to fail with "src refspec does not match".
-  const { code } = await execWithOutput('git', ['tag', '-l', tag], {
-    ignoreReturnCode: true,
-  })
-  if (code !== 0) {
+  const { code: tagListCode } = await execWithOutput(
+    'git',
+    ['tag', '-l', tag],
+    { ignoreReturnCode: true },
+  )
+  if (tagListCode !== 0) {
     return
   }
-  await exec('git', ['push', 'origin', tag], {
-    ignoreReturnCode: true,
-  })
+  const { stderr, code } = await execWithOutput(
+    'git',
+    ['push', 'origin', tag],
+    { ignoreReturnCode: true },
+  )
+  if (code !== 0 && !stderr.includes('already exists')) {
+    throw new Error(`Failed to push tag ${tag}: ${stderr}`)
+  }
 }
 
 export const switchToMaybeExistingBranch = async (branch: string) => {

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -33,6 +33,16 @@ export const pushTags = async () => {
 }
 
 export const pushTag = async (tag: string) => {
+  // Check if the tag exists locally before attempting to push.
+  // In Changesets v3, the git-tag command may report tags that were
+  // "skipped (already exist)" on the remote but don't exist locally,
+  // causing `git push origin <tag>` to fail with "src refspec does not match".
+  const { code } = await execWithOutput('git', ['tag', '-l', tag], {
+    ignoreReturnCode: true,
+  })
+  if (code !== 0) {
+    return
+  }
   await exec('git', ['push', 'origin', tag], {
     ignoreReturnCode: true,
   })

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -27,11 +27,15 @@ export const push = async (
 }
 
 export const pushTags = async () => {
-  await exec('git', ['push', 'origin', '--tags'])
+  await exec('git', ['push', 'origin', '--tags'], {
+    ignoreReturnCode: true,
+  })
 }
 
 export const pushTag = async (tag: string) => {
-  await exec('git', ['push', 'origin', tag])
+  await exec('git', ['push', 'origin', tag], {
+    ignoreReturnCode: true,
+  })
 }
 
 export const switchToMaybeExistingBranch = async (branch: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ import {
 export const main = async ({
   published,
   onlyChangesets,
-  // eslint-disable-next-line sonarjs/cognitive-complexity
 }: MainCommandOptions = {}) => {
   const { GITLAB_TOKEN, NPM_TOKEN } = env
 
@@ -67,69 +66,17 @@ export const main = async ({
       return
     }
     case !hasChangesets && hasPublishScript: {
-      console.log(
-        'No changesets found, attempting to publish any unpublished packages to npm',
-      )
-
-      if (NPM_TOKEN) {
-        const userNpmrcPath = `${env.HOME}/.npmrc`
-        if (await fileExists(userNpmrcPath)) {
-          console.info('Found existing user .npmrc file')
-          const userNpmrcContent = await fs.readFile(userNpmrcPath, 'utf8')
-          const authLine = userNpmrcContent.split('\n').find(line => {
-            // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
-            return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line)
-          })
-          if (authLine) {
-            console.info(
-              'Found existing auth token for the npm registry in the user .npmrc file',
-            )
-          } else {
-            console.info(
-              "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one",
-            )
-            await fs.appendFile(
-              userNpmrcPath,
-              `\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
-            )
-          }
-        } else {
-          console.info(
-            'No user .npmrc file found, creating one with NPM_TOKEN used as auth token',
-          )
-          await fs.writeFile(
-            userNpmrcPath,
-            `//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
-          )
-        }
-      } else {
-        console.info(
-          'No NPM_TOKEN found - assuming trusted publishing or npm is already authenticated',
-        )
-      }
-
-      const result = await runPublish({
-        script: publishScript,
-        gitlabToken: GITLAB_TOKEN,
-        createGitlabReleases: !FALSY_VALUES.has(
-          getInput('create_gitlab_releases'),
-        ),
+      await runPublishFlow({
+        publishScript,
+        published,
         cwd,
+        GITLAB_TOKEN,
+        NPM_TOKEN,
       })
-
-      if (result.published) {
-        setOutput('published', true)
-        setOutput('publishedPackages', result.publishedPackages)
-        exportVariable('PUBLISHED', true)
-        exportVariable('PUBLISHED_PACKAGES', result.publishedPackages)
-        if (published) {
-          execSync(published)
-        }
-      }
       return
     }
     case hasChangesets: {
-      await runVersion({
+      const result = await runVersion({
         script: getOptionalInput('version'),
         gitlabToken: GITLAB_TOKEN,
         mrTitle: getOptionalInput('title'),
@@ -142,6 +89,94 @@ export const main = async ({
       if (onlyChangesets) {
         execSync(onlyChangesets)
       }
+      // If the version command produced no file changes (e.g. in Changesets v3
+      // when there are no unreleased changesets, or all packages are already
+      // at the target version), fall through to the publish flow instead of
+      // leaving the packages unpublished.
+      if (!result.hasChanges && hasPublishScript) {
+        console.log(
+          'Version command produced no changes, attempting to publish any unpublished packages to npm',
+        )
+        await runPublishFlow({
+          publishScript,
+          published,
+          cwd,
+          GITLAB_TOKEN,
+          NPM_TOKEN,
+        })
+      }
+    }
+  }
+}
+
+async function runPublishFlow({
+  publishScript,
+  published,
+  cwd,
+  GITLAB_TOKEN,
+  NPM_TOKEN,
+}: {
+  publishScript: string
+  published?: string
+  cwd: string
+  GITLAB_TOKEN: string
+  NPM_TOKEN?: string
+}) {
+  console.log(
+    'No changesets found, attempting to publish any unpublished packages to npm',
+  )
+
+  if (NPM_TOKEN) {
+    const userNpmrcPath = `${env.HOME}/.npmrc`
+    if (await fileExists(userNpmrcPath)) {
+      console.info('Found existing user .npmrc file')
+      const userNpmrcContent = await fs.readFile(userNpmrcPath, 'utf8')
+      const authLine = userNpmrcContent.split('\n').find(line => {
+        // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
+        return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line)
+      })
+      if (authLine) {
+        console.info(
+          'Found existing auth token for the npm registry in the user .npmrc file',
+        )
+      } else {
+        console.info(
+          "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one",
+        )
+        await fs.appendFile(
+          userNpmrcPath,
+          `\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
+        )
+      }
+    } else {
+      console.info(
+        'No user .npmrc file found, creating one with NPM_TOKEN used as auth token',
+      )
+      await fs.writeFile(
+        userNpmrcPath,
+        `//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n`,
+      )
+    }
+  } else {
+    console.info(
+      'No NPM_TOKEN found - assuming trusted publishing or npm is already authenticated',
+    )
+  }
+
+  const result = await runPublish({
+    script: publishScript,
+    gitlabToken: GITLAB_TOKEN,
+    createGitlabReleases: !FALSY_VALUES.has(getInput('create_gitlab_releases')),
+    cwd,
+  })
+
+  if (result.published) {
+    setOutput('published', true)
+    setOutput('publishedPackages', result.publishedPackages)
+    exportVariable('PUBLISHED', true)
+    exportVariable('PUBLISHED_PACKAGES', result.publishedPackages)
+    if (published) {
+      execSync(published)
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,5 +177,9 @@ async function runPublishFlow({
     if (published) {
       execSync(published)
     }
+  } else if (result.exitCode !== 0) {
+    console.warn(
+      `Publish command exited with code ${result.exitCode} and no packages were published`,
+    )
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,9 @@ export const main = async ({
       return
     }
     case !hasChangesets && hasPublishScript: {
+      console.log(
+        'No changesets found, attempting to publish any unpublished packages to npm',
+      )
       await runPublishFlow({
         publishScript,
         published,
@@ -122,10 +125,6 @@ async function runPublishFlow({
   GITLAB_TOKEN: string
   NPM_TOKEN?: string
 }) {
-  console.log(
-    'No changesets found, attempting to publish any unpublished packages to npm',
-  )
-
   if (NPM_TOKEN) {
     const userNpmrcPath = `${env.HOME}/.npmrc`
     if (await fileExists(userNpmrcPath)) {

--- a/src/read-changeset-state.ts
+++ b/src/read-changeset-state.ts
@@ -1,5 +1,5 @@
 import { readPreState } from '@changesets/pre'
-import readChangesets from '@changesets/read'
+import { readChangesets } from '@changesets/read'
 import type { PreState, NewChangeset } from '@changesets/types'
 
 export interface ChangesetState {
@@ -16,8 +16,10 @@ export default async function readChangesetState(
   let changesets = await readChangesets(cwd)
 
   if (isInPreMode) {
-    const changesetsToFilter = new Set(preState.changesets)
-    changesets = changesets.filter(x => !changesetsToFilter.has(x.id))
+    // In Changesets v3, versioned prerelease changesets are stored in
+    // `.changeset/pre/` and have IDs starting with `pre/`. These should
+    // be filtered out when in pre mode, as they are already consumed.
+    changesets = changesets.filter(x => !x.id.startsWith('pre/'))
   }
 
   return {

--- a/src/run.ts
+++ b/src/run.ts
@@ -215,7 +215,7 @@ export async function runPublish({
     }
   } else {
     // Changesets v2: fall back to stdout "New tag:" parsing
-    if (tool === 'root') {
+    if (tool.type === 'root') {
       if (packages.length !== 1) {
         throw new Error(
           `No package found.` +
@@ -270,7 +270,7 @@ export async function runPublish({
           createRelease(api, {
             pkg,
             tagName:
-              tool === 'root'
+              tool.type === 'root'
                 ? `v${pkg.packageJson.version}`
                 : `${pkg.packageJson.name}@${pkg.packageJson.version}`,
           }),

--- a/src/run.ts
+++ b/src/run.ts
@@ -174,77 +174,78 @@ export async function runPublish({
         CHANGESETS_OUTPUT: outputFile,
       },
     })
+    const { packages, tool } = await getPackages(cwd)
+
+    const pushAllTags =
+      packages.length <= GITLAB_MAX_TAGS ||
+      (await api.FeatureFlags.show(
+        context.projectId,
+        'git_push_create_all_pipelines',
+      )
+        .then(({ active }) => active)
+        .catch(() => false))
+
+    if (pushAllTags) {
+      await gitUtils.pushTags()
+    }
+
+    const outputEvents = await readChangesetsOutput(outputFile)
+    const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
+
+    const releasedPackages: Package[] = []
+
+    for (const event of outputEvents) {
+      const pkg = packagesByName.get(event.packageName)
+      if (pkg === undefined) {
+        throw new Error(
+          `Package "${event.packageName}" not found.` +
+            'This is probably a bug in the action, please open an issue',
+        )
+      }
+      releasedPackages.push(pkg)
+    }
+
+    if (!pushAllTags) {
+      await Promise.all(
+        releasedPackages.map(pkg =>
+          gitUtils.pushTag(
+            `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+          ),
+        ),
+      )
+    }
+    if (createGitlabReleases) {
+      await Promise.all(
+        releasedPackages.map(pkg =>
+          limit(() =>
+            createRelease(api, {
+              pkg,
+              tagName:
+                tool.type === 'root'
+                  ? `v${pkg.packageJson.version}`
+                  : `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+            }),
+          ),
+        ),
+      )
+    }
+
+    if (releasedPackages.length > 0) {
+      return {
+        published: true,
+        publishedPackages: releasedPackages.map(pkg => ({
+          name: pkg.packageJson.name,
+          version: pkg.packageJson.version,
+        })),
+        exitCode: changesetPublishOutput.code,
+      }
+    }
+
+    return { published: false, exitCode: changesetPublishOutput.code }
   } finally {
     // Clean up the temp file on both success and failure
     await fs.rm(outputFile, { force: true })
   }
-
-  const { packages, tool } = await getPackages(cwd)
-
-  const pushAllTags =
-    packages.length <= GITLAB_MAX_TAGS ||
-    (await api.FeatureFlags.show(
-      context.projectId,
-      'git_push_create_all_pipelines',
-    )
-      .then(({ active }) => active)
-      .catch(() => false))
-
-  if (pushAllTags) {
-    await gitUtils.pushTags()
-  }
-
-  const outputEvents = await readChangesetsOutput(outputFile)
-  const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
-
-  const releasedPackages: Package[] = []
-
-  for (const event of outputEvents) {
-    const pkg = packagesByName.get(event.packageName)
-    if (pkg === undefined) {
-      throw new Error(
-        `Package "${event.packageName}" not found.` +
-          'This is probably a bug in the action, please open an issue',
-      )
-    }
-    releasedPackages.push(pkg)
-  }
-
-  if (!pushAllTags) {
-    await Promise.all(
-      releasedPackages.map(pkg =>
-        gitUtils.pushTag(`${pkg.packageJson.name}@${pkg.packageJson.version}`),
-      ),
-    )
-  }
-  if (createGitlabReleases) {
-    await Promise.all(
-      releasedPackages.map(pkg =>
-        limit(() =>
-          createRelease(api, {
-            pkg,
-            tagName:
-              tool.type === 'root'
-                ? `v${pkg.packageJson.version}`
-                : `${pkg.packageJson.name}@${pkg.packageJson.version}`,
-          }),
-        ),
-      ),
-    )
-  }
-
-  if (releasedPackages.length > 0) {
-    return {
-      published: true,
-      publishedPackages: releasedPackages.map(pkg => ({
-        name: pkg.packageJson.name,
-        version: pkg.packageJson.version,
-      })),
-      exitCode: changesetPublishOutput.code,
-    }
-  }
-
-  return { published: false, exitCode: changesetPublishOutput.code }
 }
 
 const requireChangesetsCliPkgJson = (cwd: string) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -120,16 +120,8 @@ async function readChangesetsOutput(
 
   const events: ChangesetsOutputEvent[] = []
 
-  let lineStart = 0
-  while (lineStart <= rawOutput.length) {
-    let lineEnd = rawOutput.indexOf('\n', lineStart)
-    if (lineEnd === -1) {
-      lineEnd = rawOutput.length
-    }
-    const line = rawOutput.slice(lineStart, lineEnd)
-    lineStart = lineEnd + 1
-
-    if (/^\s*$/.test(line)) {
+  for (const line of rawOutput.split('\n')) {
+    if (!line.trim()) {
       continue
     }
 
@@ -137,18 +129,20 @@ async function readChangesetsOutput(
     try {
       event = JSON.parse(line)
     } catch {
+      console.warn(`Ignoring malformed Changesets output line: ${line}`)
       continue
     }
 
     if (isChangesetsOutputEvent(event)) {
       events.push(event)
+    } else {
+      console.warn(`Ignoring unrecognized Changesets output event: ${line}`)
     }
   }
 
   return events
 }
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export async function runPublish({
   script,
   gitlabToken,
@@ -159,26 +153,31 @@ export async function runPublish({
   const [publishCommand, ...publishArgs] = script.split(/\s+/)
 
   // Changesets v3 uses a shared output file (via CHANGESETS_OUTPUT env var)
-  // to report published packages, instead of printing "New tag:" to stdout.
-  // We set up a temp file and pass it through, then fall back to stdout
-  // parsing for Changesets v2 compatibility.
+  // to report published packages as NDJSON events.
   const outputFile = path.join(
     os.tmpdir(),
     `changesets-output-${randomUUID()}.ndjson`,
   )
 
-  const changesetPublishOutput = await execWithOutput(
-    publishCommand,
-    publishArgs,
-    {
+  let changesetPublishOutput: {
+    code: number
+    stdout: string
+    stderr: string
+  }
+
+  try {
+    changesetPublishOutput = await execWithOutput(publishCommand, publishArgs, {
       cwd,
       ignoreReturnCode: true,
       env: {
         ...process.env,
         CHANGESETS_OUTPUT: outputFile,
       },
-    },
-  )
+    })
+  } finally {
+    // Clean up the temp file on both success and failure
+    await fs.rm(outputFile, { force: true })
+  }
 
   const { packages, tool } = await getPackages(cwd)
 
@@ -195,65 +194,20 @@ export async function runPublish({
     await gitUtils.pushTags()
   }
 
-  // Try reading the Changesets v3 output file first
   const outputEvents = await readChangesetsOutput(outputFile)
+  const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
 
   const releasedPackages: Package[] = []
 
-  if (outputEvents.length > 0) {
-    // Changesets v3: use output file events
-    const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
-    for (const event of outputEvents) {
-      const pkg = packagesByName.get(event.packageName)
-      if (pkg === undefined) {
-        throw new Error(
-          `Package "${event.packageName}" not found.` +
-            'This is probably a bug in the action, please open an issue',
-        )
-      }
-      releasedPackages.push(pkg)
+  for (const event of outputEvents) {
+    const pkg = packagesByName.get(event.packageName)
+    if (pkg === undefined) {
+      throw new Error(
+        `Package "${event.packageName}" not found.` +
+          'This is probably a bug in the action, please open an issue',
+      )
     }
-  } else {
-    // Changesets v2: fall back to stdout "New tag:" parsing
-    if (tool.type === 'root') {
-      if (packages.length !== 1) {
-        throw new Error(
-          `No package found.` +
-            'This is probably a bug in the action, please open an issue',
-        )
-      }
-      const pkg = packages[0]
-      const newTagRegex = /New tag:/
-
-      for (const line of changesetPublishOutput.stdout.split('\n')) {
-        const match = newTagRegex.exec(line)
-
-        if (match) {
-          releasedPackages.push(pkg)
-          break
-        }
-      }
-    } else {
-      // eslint-disable-next-line regexp/no-misleading-capturing-group, regexp/no-super-linear-backtracking, sonarjs/slow-regex
-      const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/
-      const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
-
-      for (const line of changesetPublishOutput.stdout.split('\n')) {
-        const match = newTagRegex.exec(line)
-        if (match === null) {
-          continue
-        }
-        const pkgName = match[1]
-        const pkg = packagesByName.get(pkgName)
-        if (pkg === undefined) {
-          throw new Error(
-            `Package "${pkgName}" not found.` +
-              'This is probably a bug in the action, please open an issue',
-          )
-        }
-        releasedPackages.push(pkg)
-      }
-    }
+    releasedPackages.push(pkg)
   }
 
   if (!pushAllTags) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 
 import { exec } from '@actions/exec'
@@ -72,8 +74,79 @@ export interface PublishedPackage {
 }
 
 export type PublishResult =
-  | { published: false }
-  | { published: true; publishedPackages: PublishedPackage[] }
+  | {
+      published: false
+      exitCode: number
+    }
+  | {
+      published: true
+      publishedPackages: PublishedPackage[]
+      exitCode: number
+    }
+
+interface ChangesetsOutputEvent {
+  type: string
+  tag: string
+  packageName: string
+}
+
+function isChangesetsOutputEvent(
+  value: unknown,
+): value is ChangesetsOutputEvent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    value.type === 'git-tag' &&
+    'tag' in value &&
+    typeof value.tag === 'string' &&
+    'packageName' in value &&
+    typeof value.packageName === 'string'
+  )
+}
+
+async function readChangesetsOutput(
+  outputPath: string,
+): Promise<ChangesetsOutputEvent[]> {
+  let rawOutput: string
+  try {
+    rawOutput = await fs.readFile(outputPath, 'utf8')
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === 'ENOENT') {
+      return []
+    }
+    throw err
+  }
+
+  const events: ChangesetsOutputEvent[] = []
+
+  let lineStart = 0
+  while (lineStart <= rawOutput.length) {
+    let lineEnd = rawOutput.indexOf('\n', lineStart)
+    if (lineEnd === -1) {
+      lineEnd = rawOutput.length
+    }
+    const line = rawOutput.slice(lineStart, lineEnd)
+    lineStart = lineEnd + 1
+
+    if (/^\s*$/.test(line)) {
+      continue
+    }
+
+    let event: unknown
+    try {
+      event = JSON.parse(line)
+    } catch {
+      continue
+    }
+
+    if (isChangesetsOutputEvent(event)) {
+      events.push(event)
+    }
+  }
+
+  return events
+}
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export async function runPublish({
@@ -85,10 +158,26 @@ export async function runPublish({
   const api = createApi(gitlabToken)
   const [publishCommand, ...publishArgs] = script.split(/\s+/)
 
+  // Changesets v3 uses a shared output file (via CHANGESETS_OUTPUT env var)
+  // to report published packages, instead of printing "New tag:" to stdout.
+  // We set up a temp file and pass it through, then fall back to stdout
+  // parsing for Changesets v2 compatibility.
+  const outputFile = path.join(
+    os.tmpdir(),
+    `changesets-output-${randomUUID()}.ndjson`,
+  )
+
   const changesetPublishOutput = await execWithOutput(
     publishCommand,
     publishArgs,
-    { cwd },
+    {
+      cwd,
+      ignoreReturnCode: true,
+      env: {
+        ...process.env,
+        CHANGESETS_OUTPUT: outputFile,
+      },
+    },
   )
 
   const { packages, tool } = await getPackages(cwd)
@@ -106,71 +195,88 @@ export async function runPublish({
     await gitUtils.pushTags()
   }
 
+  // Try reading the Changesets v3 output file first
+  const outputEvents = await readChangesetsOutput(outputFile)
+
   const releasedPackages: Package[] = []
 
-  if (tool === 'root') {
-    if (packages.length !== 1) {
-      throw new Error(
-        `No package found.` +
-          'This is probably a bug in the action, please open an issue',
-      )
-    }
-    const pkg = packages[0]
-    const newTagRegex = /New tag:/
-
-    for (const line of changesetPublishOutput.stdout.split('\n')) {
-      const match = newTagRegex.exec(line)
-
-      if (match) {
-        releasedPackages.push(pkg)
-        const tagName = `v${pkg.packageJson.version}`
-        if (createGitlabReleases) {
-          await createRelease(api, { pkg, tagName })
-        }
-        break
-      }
-    }
-  } else {
-    // eslint-disable-next-line regexp/no-misleading-capturing-group, regexp/no-super-linear-backtracking, sonarjs/slow-regex
-    const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/
+  if (outputEvents.length > 0) {
+    // Changesets v3: use output file events
     const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
-
-    for (const line of changesetPublishOutput.stdout.split('\n')) {
-      const match = newTagRegex.exec(line)
-      if (match === null) {
-        continue
-      }
-      const pkgName = match[1]
-      const pkg = packagesByName.get(pkgName)
+    for (const event of outputEvents) {
+      const pkg = packagesByName.get(event.packageName)
       if (pkg === undefined) {
         throw new Error(
-          `Package "${pkgName}" not found.` +
+          `Package "${event.packageName}" not found.` +
             'This is probably a bug in the action, please open an issue',
         )
       }
       releasedPackages.push(pkg)
     }
-    if (!pushAllTags) {
-      await Promise.all(
-        releasedPackages.map(pkg =>
-          gitUtils.pushTag(
-            `${pkg.packageJson.name}@${pkg.packageJson.version}`,
-          ),
-        ),
-      )
+  } else {
+    // Changesets v2: fall back to stdout "New tag:" parsing
+    if (tool === 'root') {
+      if (packages.length !== 1) {
+        throw new Error(
+          `No package found.` +
+            'This is probably a bug in the action, please open an issue',
+        )
+      }
+      const pkg = packages[0]
+      const newTagRegex = /New tag:/
+
+      for (const line of changesetPublishOutput.stdout.split('\n')) {
+        const match = newTagRegex.exec(line)
+
+        if (match) {
+          releasedPackages.push(pkg)
+          break
+        }
+      }
+    } else {
+      // eslint-disable-next-line regexp/no-misleading-capturing-group, regexp/no-super-linear-backtracking, sonarjs/slow-regex
+      const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/
+      const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]))
+
+      for (const line of changesetPublishOutput.stdout.split('\n')) {
+        const match = newTagRegex.exec(line)
+        if (match === null) {
+          continue
+        }
+        const pkgName = match[1]
+        const pkg = packagesByName.get(pkgName)
+        if (pkg === undefined) {
+          throw new Error(
+            `Package "${pkgName}" not found.` +
+              'This is probably a bug in the action, please open an issue',
+          )
+        }
+        releasedPackages.push(pkg)
+      }
     }
-    if (createGitlabReleases) {
-      await Promise.all(
-        releasedPackages.map(pkg =>
-          limit(() =>
-            createRelease(api, {
-              pkg,
-              tagName: `${pkg.packageJson.name}@${pkg.packageJson.version}`,
-            }),
-          ),
+  }
+
+  if (!pushAllTags) {
+    await Promise.all(
+      releasedPackages.map(pkg =>
+        gitUtils.pushTag(`${pkg.packageJson.name}@${pkg.packageJson.version}`),
+      ),
+    )
+  }
+  if (createGitlabReleases) {
+    await Promise.all(
+      releasedPackages.map(pkg =>
+        limit(() =>
+          createRelease(api, {
+            pkg,
+            tagName:
+              tool === 'root'
+                ? `v${pkg.packageJson.version}`
+                : `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+          }),
         ),
-      )
-    }
+      ),
+    )
   }
 
   if (releasedPackages.length > 0) {
@@ -180,10 +286,11 @@ export async function runPublish({
         name: pkg.packageJson.name,
         version: pkg.packageJson.version,
       })),
+      exitCode: changesetPublishOutput.code,
     }
   }
 
-  return { published: false }
+  return { published: false, exitCode: changesetPublishOutput.code }
 }
 
 const requireChangesetsCliPkgJson = (cwd: string) => {
@@ -212,6 +319,11 @@ export interface VersionOptions {
   hasPublishScript?: boolean
 }
 
+export interface VersionResult {
+  /** Whether the version command produced any file changes */
+  hasChanges: boolean
+}
+
 export async function runVersion({
   script,
   gitlabToken,
@@ -221,7 +333,7 @@ export async function runVersion({
   commitMessage = 'Version Packages',
   removeSourceBranch = false,
   hasPublishScript = false,
-}: VersionOptions) {
+}: VersionOptions): Promise<VersionResult> {
   const currentBranch = context.ref
   const versionBranch = `changeset-release/${currentBranch}`
 
@@ -238,9 +350,11 @@ export async function runVersion({
 
   const versionsByDirectory = await getVersionsByDirectory(cwd)
 
+  // Changesets v3 exits with code 1 when there are no unreleased changesets,
+  // so we ignore the return code and check for actual file changes instead.
   if (script) {
     const [versionCommand, ...versionArgs] = script.split(/\s+/)
-    await exec(versionCommand, versionArgs, { cwd })
+    await exec(versionCommand, versionArgs, { cwd, ignoreReturnCode: true })
   } else {
     const changesetsCliPkgJson = requireChangesetsCliPkgJson(cwd)
     const cmd = semver.lt(changesetsCliPkgJson.version, '2.0.0')
@@ -248,7 +362,20 @@ export async function runVersion({
       : 'version'
     await exec('node', [resolveFrom(cwd, '@changesets/cli/bin.js'), cmd], {
       cwd,
+      ignoreReturnCode: true,
     })
+  }
+
+  // After running the version command, check if there are actual file changes.
+  // In Changesets v3, the version command may exit with code 1 when there are
+  // no unreleased changesets. Even if it exits 0, it might produce no file
+  // changes if all packages are already at the target version.
+  // In either case, we should not create or update an empty release MR.
+  if (await gitUtils.checkIfClean()) {
+    console.log(
+      'No file changes after running version command, skipping merge request creation',
+    )
+    return { hasChanges: false }
   }
 
   const changedPackages = await getChangedPackages(cwd, versionsByDirectory)
@@ -346,4 +473,6 @@ ${
       labels,
     })
   }
+
+  return { hasChanges: true }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,11 @@ export function getChangelogEntry(changelog: string, version: string) {
 export async function execWithOutput(
   command: string,
   args?: string[],
-  options?: { ignoreReturnCode?: boolean; cwd?: string },
+  options?: {
+    ignoreReturnCode?: boolean
+    cwd?: string
+    env?: Record<string, string>
+  },
 ) {
   let myOutput = ''
   let myError = ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,13 +1758,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.5.5":
-  version: 7.29.7
-  resolution: "@babel/runtime@npm:7.29.7"
-  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
-  languageName: node
-  linkType: hard
-
 "@babel/template@npm:^7.27.2, @babel/template@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/template@npm:7.29.7"
@@ -1808,257 +1801,225 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/apply-release-plan@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@changesets/apply-release-plan@npm:7.1.1"
+"@changesets/apply-release-plan@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@changesets/apply-release-plan@npm:8.0.0"
   dependencies:
-    "@changesets/config": "npm:^3.1.4"
-    "@changesets/get-version-range-type": "npm:^0.4.0"
-    "@changesets/git": "npm:^3.0.4"
-    "@changesets/should-skip-package": "npm:^0.1.2"
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    detect-indent: "npm:^6.0.0"
-    fs-extra: "npm:^7.0.1"
-    lodash.startcase: "npm:^4.4.0"
-    outdent: "npm:^0.5.0"
-    prettier: "npm:^2.7.1"
-    resolve-from: "npm:^5.0.0"
-    semver: "npm:^7.5.3"
-  checksum: 10c0/27de184e74e8e48b43fca1f73e7c7a2887b0cdacfe7ba9c09cdc4547dff0de1587bed5fe2d5ec0a3754fa422f6b8a528e0ac452c22ac7a6ae5211f5ac089bfb2
+    "@changesets/config": "npm:^4.0.0"
+    "@changesets/format": "npm:^0.1.1"
+    "@changesets/git": "npm:^4.0.0"
+    "@changesets/should-skip-package": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    import-meta-resolve: "npm:^4.2.0"
+    jsonc-parser: "npm:^3.3.1"
+    semver: "npm:^7.8.1"
+  checksum: 10c0/c2b35867e34a6bf4ac1f0b2d329d7fe9b0c25f580a9bf3fb106ad025566b4f4a4cf5f444c5d1287e8d482827a286163afd77992a21acb85d560826a26e6a03ed
   languageName: node
   linkType: hard
 
-"@changesets/assemble-release-plan@npm:^6.0.10, @changesets/assemble-release-plan@npm:^6.0.6":
-  version: 6.0.10
-  resolution: "@changesets/assemble-release-plan@npm:6.0.10"
+"@changesets/assemble-release-plan@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@changesets/assemble-release-plan@npm:7.0.0"
   dependencies:
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/get-dependents-graph": "npm:^2.1.4"
-    "@changesets/should-skip-package": "npm:^0.1.2"
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    semver: "npm:^7.5.3"
-  checksum: 10c0/a0ea336a5f19f8d0a97b684983bcd9c3bb8d6881b7b6abd5b482b301795ae4600924c188982f5f98dc48ac88e94a063b66ab72659041eb2623ade3e35f05d555
+    "@changesets/errors": "npm:^1.0.0"
+    "@changesets/get-dependents-graph": "npm:^3.0.0"
+    "@changesets/should-skip-package": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    semver: "npm:^7.8.1"
+  checksum: 10c0/2544759583889865487aec744e948c6d84206a42aa593430436ace83003fe00d3880ef623114c396cd5fd883eccb1e03fc4a719ba5c33038a8556df8fca4b9b7
   languageName: node
   linkType: hard
 
-"@changesets/changelog-git@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@changesets/changelog-git@npm:0.2.1"
+"@changesets/changelog-git@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/changelog-git@npm:1.0.0"
   dependencies:
-    "@changesets/types": "npm:^6.1.0"
-  checksum: 10c0/6a6fb315ffb2266fcb8f32ae9a60ccdb5436e52350a2f53beacf9822d3355f9052aba5001a718e12af472b4a8fabd69b408d0b11c02ac909ba7a183d27a9f7fd
+    "@changesets/types": "npm:^7.0.0"
+  checksum: 10c0/f0f0ab31e6e6ac35ecdae46a521d4c84aab77bbb035898e364d8f9082391b2b8064ba33d9f97d4f1526195f8278f41910c72382b12fcc0092d5bb9ff3ae05310
   languageName: node
   linkType: hard
 
-"@changesets/changelog-github@npm:^0.5.1":
-  version: 0.5.2
-  resolution: "@changesets/changelog-github@npm:0.5.2"
+"@changesets/changelog-github@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/changelog-github@npm:1.0.0"
   dependencies:
-    "@changesets/get-github-info": "npm:^0.7.0"
-    "@changesets/types": "npm:^6.1.0"
-    dotenv: "npm:^8.1.0"
-  checksum: 10c0/c2dbf767f7f18f44539d92f7fd0f42ef6fc33d8f3583a0cd2a558fe8242a4f2db178bf77497c73780652afbae55704b14c32dd33f4d61ebdf28113a0af08f19b
+    "@changesets/get-github-info": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+  checksum: 10c0/c53082e33b9b78330324634407e8ec06e3d1466d6266e0cd8cb3d72955b0a12009d09b3b09e560fe444b47fca31029ad442ba1af55aa04db401f6f7bbf1353a0
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:^2.29.0":
-  version: 2.31.1
-  resolution: "@changesets/cli@npm:2.31.1"
+"@changesets/cli@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@changesets/cli@npm:3.0.1"
   dependencies:
-    "@changesets/apply-release-plan": "npm:^7.1.1"
-    "@changesets/assemble-release-plan": "npm:^6.0.10"
-    "@changesets/changelog-git": "npm:^0.2.1"
-    "@changesets/config": "npm:^3.1.4"
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/get-dependents-graph": "npm:^2.1.4"
-    "@changesets/get-release-plan": "npm:^4.0.16"
-    "@changesets/git": "npm:^3.0.4"
-    "@changesets/logger": "npm:^0.1.1"
-    "@changesets/pre": "npm:^2.0.2"
-    "@changesets/read": "npm:^0.6.7"
-    "@changesets/should-skip-package": "npm:^0.1.2"
-    "@changesets/types": "npm:^6.1.0"
-    "@changesets/write": "npm:^0.4.0"
-    "@inquirer/external-editor": "npm:^1.0.2"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    ansi-colors: "npm:^4.1.3"
-    enquirer: "npm:^2.4.1"
-    fs-extra: "npm:^7.0.1"
-    mri: "npm:^1.2.0"
-    package-manager-detector: "npm:^0.2.0"
-    picocolors: "npm:^1.1.0"
-    resolve-from: "npm:^5.0.0"
-    semver: "npm:^7.5.3"
-    spawndamnit: "npm:^3.0.1"
-    term-size: "npm:^2.1.0"
+    "@changesets/apply-release-plan": "npm:^8.0.0"
+    "@changesets/assemble-release-plan": "npm:^7.0.0"
+    "@changesets/changelog-git": "npm:^1.0.0"
+    "@changesets/config": "npm:^4.0.0"
+    "@changesets/errors": "npm:^1.0.0"
+    "@changesets/get-dependents-graph": "npm:^3.0.0"
+    "@changesets/git": "npm:^4.0.0"
+    "@changesets/pre": "npm:^3.0.0"
+    "@changesets/read": "npm:^1.0.0"
+    "@changesets/should-skip-package": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    "@changesets/write": "npm:^1.0.1"
+    "@clack/prompts": "npm:^1.7.0"
+    "@manypkg/get-packages": "npm:^3.1.0"
+    "@pnpm/deps.graph-sequencer": "npm:^1100.0.1"
+    cac: "npm:^7.0.0"
+    import-meta-resolve: "npm:^4.2.0"
+    launch-editor: "npm:^2.14.1"
+    package-manager-detector: "npm:^1.6.0"
+    semver: "npm:^7.8.1"
+    tinyexec: "npm:^1.3.0"
   bin:
     changeset: bin.js
-  checksum: 10c0/375789e85def0bb303ada45d5085c92765010e6b88b8252eb459346ac8a94eba098c9cb8ad416241757796a8828c417fc9e0a23011bd3a74ce33eef013d8311a
+  checksum: 10c0/8ff35257fcfc3b627196c16fa2a130e130d57e089fce13c791037222cccf9883e7face01d5cc762f022e0f2057ea05a4a3b0fe9f3a1c0902ea5e274693b817ad
   languageName: node
   linkType: hard
 
-"@changesets/config@npm:^3.1.1, @changesets/config@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "@changesets/config@npm:3.1.4"
+"@changesets/config@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@changesets/config@npm:4.0.0"
   dependencies:
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/get-dependents-graph": "npm:^2.1.4"
-    "@changesets/logger": "npm:^0.1.1"
-    "@changesets/should-skip-package": "npm:^0.1.2"
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    fs-extra: "npm:^7.0.1"
-    micromatch: "npm:^4.0.8"
-  checksum: 10c0/1c0e7975aa719e2c87dfda3f5a1eb81b9f4852cdfb5b5c9d181fa2f8f485e92370b3bdfdb6f666432207dd75a3f79fa8fffe7847d48fb11308acb5ecf327bc12
+    "@changesets/get-dependents-graph": "npm:^3.0.0"
+    "@changesets/should-skip-package": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    "@manypkg/get-packages": "npm:^3.1.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/484cd32c509534cb0f46a28b7e18fafc9967ebf920e8df694603dcd83fdf49491b180e0f446c0923e471a984b5695ed1891f1b8a2a5a8ebcee84d27d29779533
   languageName: node
   linkType: hard
 
-"@changesets/errors@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@changesets/errors@npm:0.2.0"
-  dependencies:
-    extendable-error: "npm:^0.1.5"
-  checksum: 10c0/f2757c752ab04e9733b0dfd7903f1caf873f9e603794c4d9ea2294af4f937c73d07273c24be864ad0c30b6a98424360d5b96a6eab14f97f3cf2cbfd3763b95c1
+"@changesets/errors@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/errors@npm:1.0.0"
+  checksum: 10c0/502439fb046b9916e8a0745374c75fa80883b0bdeea92aa2e85be07b8675dcdb50df5bd108ce66eddbda1f8863be750bf817301c9d4904c2168305df870e3f9f
   languageName: node
   linkType: hard
 
-"@changesets/get-dependents-graph@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@changesets/get-dependents-graph@npm:2.1.4"
-  dependencies:
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    picocolors: "npm:^1.1.0"
-    semver: "npm:^7.5.3"
-  checksum: 10c0/37b12ba42f16c458d0b574bcafa0247ff2b9a218686a64c86fc75bccc9ba3982f9c27206542941cf3a0563d9b199f40a830682b45e9fd902536de91344cbd0a2
-  languageName: node
-  linkType: hard
-
-"@changesets/get-github-info@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@changesets/get-github-info@npm:0.7.0"
-  dependencies:
-    dataloader: "npm:^1.4.0"
-    node-fetch: "npm:^2.5.0"
-  checksum: 10c0/3a4e497a0d05ea9cb1a17d2193f13d865d2dab8dc6e9162c63c2ffa2719338c27bfa897481feed9abf484075a27284e8c050210cff7b7dedde6a18303440e4d8
-  languageName: node
-  linkType: hard
-
-"@changesets/get-release-plan@npm:^4.0.16":
-  version: 4.0.16
-  resolution: "@changesets/get-release-plan@npm:4.0.16"
-  dependencies:
-    "@changesets/assemble-release-plan": "npm:^6.0.10"
-    "@changesets/config": "npm:^3.1.4"
-    "@changesets/pre": "npm:^2.0.2"
-    "@changesets/read": "npm:^0.6.7"
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-  checksum: 10c0/4be4553e13fe331f6d5b2ed98fece21c8d2b38c04a0543f726a0398b7538ef8fd073d712c35ae4540ed4fc6f84f08de6335318bc09dd562b189fb6968d049e95
-  languageName: node
-  linkType: hard
-
-"@changesets/get-version-range-type@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@changesets/get-version-range-type@npm:0.4.0"
-  checksum: 10c0/e466208c8383489a383f37958d8b5b9aed38539f9287b47fe155a2e8855973f6960fb1724a1ee33b11580d65e1011059045ee654e8ef51e4783017d8989c9d3f
-  languageName: node
-  linkType: hard
-
-"@changesets/git@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@changesets/git@npm:3.0.4"
-  dependencies:
-    "@changesets/errors": "npm:^0.2.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    is-subdir: "npm:^1.1.1"
-    micromatch: "npm:^4.0.8"
-    spawndamnit: "npm:^3.0.1"
-  checksum: 10c0/4abbdc1dec6ddc50b6ad927d9eba4f23acd775fdff615415813099befb0cecd1b0f56ceea5e18a5a3cbbb919d68179366074b02a954fbf4016501e5fd125d2b5
-  languageName: node
-  linkType: hard
-
-"@changesets/logger@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@changesets/logger@npm:0.1.1"
-  dependencies:
-    picocolors: "npm:^1.1.0"
-  checksum: 10c0/a0933b5bd4d99e10730b22612dc1bdfd25b8804c5b48f8cada050bf5c7a89b2ae9a61687f846a5e9e5d379a95b59fef795c8d5d91e49a251f8da2be76133f83f
-  languageName: node
-  linkType: hard
-
-"@changesets/parse@npm:^0.4.1, @changesets/parse@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@changesets/parse@npm:0.4.3"
-  dependencies:
-    "@changesets/types": "npm:^6.1.0"
-    js-yaml: "npm:^4.1.1"
-  checksum: 10c0/4d8488eaf224974ae335fec964dc1dc486abcfa9f96856cf4267c2765b02ed6af1778375ec03d38252ebab9e191aa4a11c5f37a6ad42e907e08290fed2b9690c
-  languageName: node
-  linkType: hard
-
-"@changesets/pre@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@changesets/pre@npm:2.0.2"
-  dependencies:
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    fs-extra: "npm:^7.0.1"
-  checksum: 10c0/0af9396d84c47a88d79b757e9db4e3579b6620260f92c243b8349e7fcefca3c2652583f6d215c13115bed5d5cdc30c975f307fd6acbb89d205b1ba2ae403b918
-  languageName: node
-  linkType: hard
-
-"@changesets/read@npm:^0.6.3, @changesets/read@npm:^0.6.7":
-  version: 0.6.7
-  resolution: "@changesets/read@npm:0.6.7"
-  dependencies:
-    "@changesets/git": "npm:^3.0.4"
-    "@changesets/logger": "npm:^0.1.1"
-    "@changesets/parse": "npm:^0.4.3"
-    "@changesets/types": "npm:^6.1.0"
-    fs-extra: "npm:^7.0.1"
-    p-filter: "npm:^2.1.0"
-    picocolors: "npm:^1.1.0"
-  checksum: 10c0/eebda5f5cea8684b9cb470e74cd5e67043a62ca54452ac88bb1a998bebeee1a2e3a642dc76818155a145863551c65f10f9c4ff85378b0419179fc60049edbbc6
-  languageName: node
-  linkType: hard
-
-"@changesets/should-skip-package@npm:^0.1.2":
+"@changesets/format@npm:^0.1.1":
   version: 0.1.2
-  resolution: "@changesets/should-skip-package@npm:0.1.2"
+  resolution: "@changesets/format@npm:0.1.2"
   dependencies:
-    "@changesets/types": "npm:^6.1.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
-  checksum: 10c0/484e339e7d6e6950e12bff4eda6e8eccb077c0fbb1f09dd95d2ae948b715226a838c71eaf50cd2d7e0e631ce3bfb1ca93ac752436e6feae5b87aece2e917b440
+    package-manager-detector: "npm:^1.8.0"
+    tinyexec: "npm:^1.3.0"
+  checksum: 10c0/fdb35b885b0923c2fac48433f5d633cc1a091f10e589eb65e3cd33c6702864ea26ef41d7bb434f0c91715dafa609442b91a780e84089b9bd33b7906d65d13f39
   languageName: node
   linkType: hard
 
-"@changesets/types@npm:^4.0.1":
-  version: 4.1.0
-  resolution: "@changesets/types@npm:4.1.0"
-  checksum: 10c0/a372ad21f6a1e0d4ce6c19573c1ca269eef1ad53c26751ad9515a24f003e7c49dcd859dbb1fedb6badaf7be956c1559e8798304039e0ec0da2d9a68583f13464
-  languageName: node
-  linkType: hard
-
-"@changesets/types@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@changesets/types@npm:6.1.0"
-  checksum: 10c0/b4cea3a4465d1eaf0bbd7be1e404aca5a055a61d4cc72aadcb73bbbda1670b4022736b8d3052616cbf1f451afa0637545d077697f4b923236539af9cd5abce6c
-  languageName: node
-  linkType: hard
-
-"@changesets/write@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@changesets/write@npm:0.4.0"
+"@changesets/get-dependents-graph@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@changesets/get-dependents-graph@npm:3.0.0"
   dependencies:
-    "@changesets/types": "npm:^6.1.0"
-    fs-extra: "npm:^7.0.1"
-    human-id: "npm:^4.1.1"
-    prettier: "npm:^2.7.1"
-  checksum: 10c0/311f4d0e536d1b5f2d3f9053537d62b2d4cdbd51e1d2767807ac9d1e0f380367f915d2ad370e5c73902d5a54bffd282d53fff5418c8ad31df51751d652bea826
+    "@changesets/types": "npm:^7.0.0"
+    semver: "npm:^7.8.1"
+  checksum: 10c0/ab675098db0b92f61115952fb793620bb5b76e502bad5f7f63bcc85a50e5515f70e08957be87381a58141ab2078bf94dd92df86efa55e73227e7604ba6a3968b
+  languageName: node
+  linkType: hard
+
+"@changesets/get-github-info@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/get-github-info@npm:1.0.0"
+  dependencies:
+    dataloader: "npm:^2.2.3"
+  checksum: 10c0/ae395c58bb360a425e09f07b342f6de49fdb1e21e9c196a9a821f87d6999fdbaab0e3c588ab5a748e54921d143912b2a9f44c4e7f1761944a7c6106a8449073f
+  languageName: node
+  linkType: hard
+
+"@changesets/git@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@changesets/git@npm:4.0.0"
+  dependencies:
+    "@changesets/errors": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    "@manypkg/get-packages": "npm:^3.1.0"
+    picomatch: "npm:^4.0.4"
+    tinyexec: "npm:^1.3.0"
+  checksum: 10c0/8a286cf6ae6ac43d4394b3d8f8a97966ce3db583a0481126d73d87849d569911e5ba1384ac1344d69f71f04d603fab47a2b105744455f7b18a310840f35384d5
+  languageName: node
+  linkType: hard
+
+"@changesets/parse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/parse@npm:1.0.0"
+  dependencies:
+    "@changesets/types": "npm:^7.0.0"
+    yaml: "npm:^2.9.0"
+  checksum: 10c0/76e93b099015420dfc08f3e3a9321ea2512659d8946d1ed86de64899b52d37faa87173cc80ead5d313ffce2f829ce380a0188c0a1cccaad48350e7c6a83720d0
+  languageName: node
+  linkType: hard
+
+"@changesets/pre@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@changesets/pre@npm:3.0.0"
+  dependencies:
+    "@changesets/errors": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+    "@manypkg/get-packages": "npm:^3.1.0"
+  checksum: 10c0/56e49668f25cabf50dcab12b6ae20fd7dbeba628390149d38a9075b05c41b954d4fbcebe7535878087c5f0b707ce96b90b727286850c71d6d321477bd1a1c18e
+  languageName: node
+  linkType: hard
+
+"@changesets/read@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/read@npm:1.0.0"
+  dependencies:
+    "@changesets/git": "npm:^4.0.0"
+    "@changesets/parse": "npm:^1.0.0"
+    "@changesets/types": "npm:^7.0.0"
+  checksum: 10c0/d82e6c89049d4bf86669229437e6bfccd87e6a0cb456c1567b221330c3d7efbeb463a25a0fbfc7fe192c3e6f31166c21fa0d08fcd27fdbba16e04fdae6495a52
+  languageName: node
+  linkType: hard
+
+"@changesets/should-skip-package@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@changesets/should-skip-package@npm:1.0.0"
+  dependencies:
+    "@changesets/types": "npm:^7.0.0"
+  checksum: 10c0/9beb51e7a6a6d678fbfe60efca4646d7daf117ffb90d3dbe3e8b07806f87383cf2a49b0e15b5fe2b827b69f61c0cf7cb77c4bf27b403c2ce835c5ba7990ed0e5
+  languageName: node
+  linkType: hard
+
+"@changesets/types@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@changesets/types@npm:7.0.0"
+  checksum: 10c0/494e09ff94968c1c81521f5ac8c6ab60a1e30d7d0cd9ea7f83c2cbac92efba38b03e008ee6fb4592d90b05d69bad864b6ae8155827d52a51c652f5c24d36ec83
+  languageName: node
+  linkType: hard
+
+"@changesets/write@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@changesets/write@npm:1.0.1"
+  dependencies:
+    "@changesets/format": "npm:^0.1.1"
+    "@changesets/types": "npm:^7.0.0"
+    human-id: "npm:^4.2.0"
+  checksum: 10c0/c9cb074a8c524db1327e54dc1379ff4b50d3a4915409a3e5abe1edaf1ce45f6dafc6c8aced17a1f3eebfa162241b5fd8ea74fc751d2e24df56c2966e4169fcaf
+  languageName: node
+  linkType: hard
+
+"@clack/core@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@clack/core@npm:1.4.3"
+  dependencies:
+    fast-wrap-ansi: "npm:^0.2.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/16cda430974bc02844cfa6e3f0e6e19695d97e915a580ab74603d34a1f00dcbdd8dc856adc3f89405e3555b5cf42568ae8687e748cb92c3434fe4d9fc7ebe664
+  languageName: node
+  linkType: hard
+
+"@clack/prompts@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@clack/prompts@npm:1.7.0"
+  dependencies:
+    "@clack/core": "npm:1.4.3"
+    fast-string-width: "npm:^3.0.2"
+    fast-wrap-ansi: "npm:^0.2.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/a11e4f8d4a03cfe2d9eb21c3263f0252648573977b96e495a7d4f159f7efa929fe775a6ac3fe7ae30d8acb72514d94418a2c4335855d05b575a41aa885c9ff26
   languageName: node
   linkType: hard
 
@@ -2860,21 +2821,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/external-editor@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "@inquirer/external-editor@npm:1.0.3"
-  dependencies:
-    chardet: "npm:^2.1.1"
-    iconv-lite: "npm:^0.7.0"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/82951cb7f3762dd78cca2ea291396841e3f4adfe26004b5badfed1cec4b6a04bb567dff94d0e41b35c61bdd7957317c64c22f58074d14b238d44e44d9e420019
-  languageName: node
-  linkType: hard
-
 "@isaacs/balanced-match@npm:^4.0.1":
   version: 4.0.1
   resolution: "@isaacs/balanced-match@npm:4.0.1"
@@ -2988,29 +2934,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@manypkg/find-root@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@manypkg/find-root@npm:1.1.0"
+"@manypkg/find-root@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@manypkg/find-root@npm:3.1.0"
   dependencies:
-    "@babel/runtime": "npm:^7.5.5"
-    "@types/node": "npm:^12.7.1"
-    find-up: "npm:^4.1.0"
-    fs-extra: "npm:^8.1.0"
-  checksum: 10c0/0ee907698e6c73d6f1821ff630f3fec6dcf38260817c8752fec8991ac38b95ba431ab11c2773ddf9beb33d0e057f1122b00e8ffc9b8411b3fd24151413626fa6
+    "@manypkg/tools": "npm:^2.1.0"
+  checksum: 10c0/15b3f5c5c66881af88c1c70dcec805237a2b7e1d541ca7687aade00978680024f8e77ca2f4bac1415e00377f2e78a998d842c345c288d3e69383d50280620b1c
   languageName: node
   linkType: hard
 
-"@manypkg/get-packages@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@manypkg/get-packages@npm:1.1.3"
+"@manypkg/get-packages@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@manypkg/get-packages@npm:3.1.0"
   dependencies:
-    "@babel/runtime": "npm:^7.5.5"
-    "@changesets/types": "npm:^4.0.1"
-    "@manypkg/find-root": "npm:^1.1.0"
-    fs-extra: "npm:^8.1.0"
-    globby: "npm:^11.0.0"
-    read-yaml-file: "npm:^1.1.0"
-  checksum: 10c0/f05907d1174ae28861eaa06d0efdc144f773d9a4b8b65e1e7cdc01eb93361d335351b4a336e05c6aac02661be39e8809a3f7ad28bc67b6b338071434ab442130
+    "@manypkg/find-root": "npm:^3.1.0"
+    "@manypkg/tools": "npm:^2.1.0"
+  checksum: 10c0/e8baabd85a13f4537ae22124d5e53f1523ba0653f33006da45fc8bd642e0134786a6aad9d0a7ed99282ae20a80687ef5700bd72980441627b5c96658503ad83d
+  languageName: node
+  linkType: hard
+
+"@manypkg/tools@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "@manypkg/tools@npm:2.1.2"
+  dependencies:
+    jju: "npm:^1.4.0"
+    tinyglobby: "npm:^0.2.13"
+    yaml: "npm:^2.9.0"
+  checksum: 10c0/05c8ece3b3b3ff170765ecf230f0a5408543f1ad43f8b5dc97651adff0ffed3d860dabdd1e2d1068aa247832d473c4de583791675b8f3d07568da4cab2a0ebc3
   languageName: node
   linkType: hard
 
@@ -3455,6 +3405,13 @@ __metadata:
     "@pkgr/core": "npm:^0.3.0"
     tinyglobby: "npm:^0.2.14"
   checksum: 10c0/d61cb1a2053c5b5eca97c2884bb238a4cf185f83345d36e272843588c483b5a51e84060189e0c87d2d8412929aeff473dad0667b5f369187d481dee61e75c2a9
+  languageName: node
+  linkType: hard
+
+"@pnpm/deps.graph-sequencer@npm:^1100.0.1":
+  version: 1100.0.1
+  resolution: "@pnpm/deps.graph-sequencer@npm:1100.0.1"
+  checksum: 10c0/b38a152e1184055a358e7c522f068572e84759a88dfc56c98a349125b11d3cce72e452424c235af5cf18258a5034f88fe203c72ba57ffbe70b297afc50d08dea
   languageName: node
   linkType: hard
 
@@ -4088,13 +4045,6 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.21.0"
   checksum: 10c0/f2ba54d3d1fb92e1c57c78d32c3a17655b1e87363b707136f55c422b4838d4054901ce5d27f75bb0e5ecb7ebfee3804e0987822d22b473473008091857a09353
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^12.7.1":
-  version: 12.20.55
-  resolution: "@types/node@npm:12.20.55"
-  checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
   languageName: node
   linkType: hard
 
@@ -4985,7 +4935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
+"ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.1":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
@@ -5036,15 +4986,6 @@ __metadata:
   version: 0.0.2
   resolution: "are-docs-informative@npm:0.0.2"
   checksum: 10c0/f0326981bd699c372d268b526b170a28f2e1aec2cf99d7de0686083528427ecdf6ae41fef5d9988e224a5616298af747ad8a76e7306b0a7c97cc085a99636d60
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
   languageName: node
   linkType: hard
 
@@ -5260,15 +5201,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-path-resolve@npm:1.0.0":
-  version: 1.0.0
-  resolution: "better-path-resolve@npm:1.0.0"
-  dependencies:
-    is-windows: "npm:^1.0.0"
-  checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
-  languageName: node
-  linkType: hard
-
 "binary-extensions@npm:^2.0.0":
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
@@ -5384,6 +5316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cac@npm:7.0.0"
+  checksum: 10c0/e9da33cb9f0425546ae92a450d479276f9969a050fe64f5d6fedf058bdd87f22a370797fe1c158e07655fa9fc183749df7cb2037431e3772faa7bee9919fb763
+  languageName: node
+  linkType: hard
+
 "cacheable-lookup@npm:^5.0.3":
   version: 5.0.4
   resolution: "cacheable-lookup@npm:5.0.4"
@@ -5491,17 +5430,17 @@ __metadata:
     "@1stg/common-config": "npm:^13.0.1"
     "@actions/core": "npm:^2.0.3"
     "@actions/exec": "npm:^1.1.1"
-    "@changesets/assemble-release-plan": "npm:^6.0.6"
-    "@changesets/changelog-github": "npm:^0.5.1"
-    "@changesets/cli": "npm:^2.29.0"
-    "@changesets/config": "npm:^3.1.1"
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/parse": "npm:^0.4.1"
-    "@changesets/pre": "npm:^2.0.2"
-    "@changesets/read": "npm:^0.6.3"
+    "@changesets/assemble-release-plan": "npm:^7.0.0"
+    "@changesets/changelog-github": "npm:^1.0.0"
+    "@changesets/cli": "npm:^3.0.0"
+    "@changesets/config": "npm:^4.0.0"
+    "@changesets/errors": "npm:^1.0.0"
+    "@changesets/parse": "npm:^1.0.0"
+    "@changesets/pre": "npm:^3.0.0"
+    "@changesets/read": "npm:^1.0.0"
     "@commitlint/cli": "npm:^19.8.0"
     "@gitbeaker/rest": "npm:^42.2.0"
-    "@manypkg/get-packages": "npm:^1.1.3"
+    "@manypkg/get-packages": "npm:^3.1.0"
     "@pkgr/rollup": "npm:^6.0.3"
     "@types/global-agent": "npm:^3.0.0"
     "@types/micromatch": "npm:^4.0.9"
@@ -5574,13 +5513,6 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
-  languageName: node
-  linkType: hard
-
-"chardet@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "chardet@npm:2.2.0"
-  checksum: 10c0/8d43a1dd3ce535aa070d04139fae62f879b4388394eb1d857364ce416675a1f0f63974fba8208e9cd11b49e1a6da3e65ea6393d0fc654a8c4217c0d74c16b1b4
   languageName: node
   linkType: hard
 
@@ -5900,7 +5832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -5948,10 +5880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "dataloader@npm:1.4.0"
-  checksum: 10c0/5fa4c843b9e60195092f1fc7e2acaff318ed46886dc670ddff683bc560f12d4079e6d1e77749501b7e111a8582d26a2aa2a2fbe6d7d5e1520cef64f4e1fd242d
+"dataloader@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "dataloader@npm:2.2.3"
+  checksum: 10c0/9b9a056fbc863ca86da87d59e053e871e263b4966aa4d55e40d61a65e96815fae5530ca220629064ca5f8e3000c0c4ec93292e170c38ff393fb34256b4d7c1aa
   languageName: node
   linkType: hard
 
@@ -6049,13 +5981,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-indent@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "detect-indent@npm:6.1.0"
-  checksum: 10c0/dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
-  languageName: node
-  linkType: hard
-
 "detect-installed@npm:2.0.4":
   version: 2.0.4
   resolution: "detect-installed@npm:2.0.4"
@@ -6134,13 +6059,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^8.1.0":
-  version: 8.6.0
-  resolution: "dotenv@npm:8.6.0"
-  checksum: 10c0/6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f
-  languageName: node
-  linkType: hard
-
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -6213,7 +6131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:2.4.1, enquirer@npm:^2.4.1":
+"enquirer@npm:2.4.1":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
   dependencies:
@@ -7042,7 +6960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
+"esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -7147,13 +7065,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extendable-error@npm:^0.1.5":
-  version: 0.1.7
-  resolution: "extendable-error@npm:0.1.7"
-  checksum: 10c0/c46648b7682448428f81b157cbfe480170fd96359c55db477a839ddeaa34905a18cba0b989bafe5e83f93c2491a3fcc7cc536063ea326ba9d72e9c6e2fe736a7
-  languageName: node
-  linkType: hard
-
 "fast-async@npm:^7.0.6":
   version: 7.0.6
   resolution: "fast-async@npm:7.0.6"
@@ -7181,7 +7092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:3, fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
+"fast-glob@npm:3, fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -7215,10 +7126,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10c0/043b8663397d14a3880ce4f3407bcda60b40db9bbeafe62863a35d1f9c69ea17c8da3fcd72de235553e6c9cd053128cde9e24ca0d4a7463208f48db3cd23d981
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.1.5
   resolution: "fast-uri@npm:3.1.5"
   checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "fast-wrap-ansi@npm:0.2.2"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10c0/1aa7be4f7cb86f4bdb14691cb6bcc0b8df8b3b89df142ade3ae1602332dcf6f990cd750a923cd581ca0847808cb4ec1aa5afaafa7a72f849e87a2a62c98fa370
   languageName: node
   linkType: hard
 
@@ -7277,16 +7213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "find-up@npm:4.1.0"
-  dependencies:
-    locate-path: "npm:^5.0.0"
-    path-exists: "npm:^4.0.0"
-  checksum: 10c0/0406ee89ebeefa2d507feb07ec366bebd8a6167ae74aa4e34fb4c4abd06cf782a3ce26ae4194d70706f72182841733f00551c209fe575cb00bd92104056e78c1
-  languageName: node
-  linkType: hard
-
 "find-up@npm:^5.0.0":
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
@@ -7339,17 +7265,6 @@ __metadata:
   version: 0.2.2
   resolution: "format@npm:0.2.2"
   checksum: 10c0/6032ba747541a43abf3e37b402b2f72ee08ebcb58bf84d816443dd228959837f1cddf1e8775b29fa27ff133f4bd146d041bfca5f9cf27f048edf3d493cf8fee6
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "fs-extra@npm:7.0.1"
-  dependencies:
-    graceful-fs: "npm:^4.1.2"
-    jsonfile: "npm:^4.0.0"
-    universalify: "npm:^0.1.0"
-  checksum: 10c0/1943bb2150007e3739921b8d13d4109abdc3cc481e53b97b7ea7f77eda1c3c642e27ae49eac3af074e3496ea02fde30f411ef410c760c70a38b92e656e5da784
   languageName: node
   linkType: hard
 
@@ -7663,20 +7578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "globby@npm:11.1.0"
-  dependencies:
-    array-union: "npm:^2.1.0"
-    dir-glob: "npm:^3.0.1"
-    fast-glob: "npm:^3.2.9"
-    ignore: "npm:^5.2.0"
-    merge2: "npm:^1.4.1"
-    slash: "npm:^3.0.0"
-  checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
-  languageName: node
-  linkType: hard
-
 "globby@npm:^14.0.0":
   version: 14.1.0
   resolution: "globby@npm:14.1.0"
@@ -7724,7 +7625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -7858,21 +7759,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-id@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "human-id@npm:4.2.0"
+"human-id@npm:^4.1.1, human-id@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "human-id@npm:4.2.1"
   bin:
     human-id: dist/cli.js
-  checksum: 10c0/80071f3b785b2e91080b5f9aa2d079c2e9a464e009ea12c035255b61d1b70beefe7eda42209dff9c1bb9a9fa58e50ada38c1b314ba3a23266a72cd5e9a453e1f
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:^0.7.0":
-  version: 0.7.3
-  resolution: "iconv-lite@npm:0.7.3"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/be2fd2414f7e94be3a63063fa0ad5919c16bc7b6e00c77eea0765ced6db405739f38dd51016583058fba25cc1d0106ba30b83fbb7a7e32f824d4db76f23d8d33
+  checksum: 10c0/e7a6f89843fc10c3827d856f862b6b65678de22d97336524ff61ad0ff9414e9c6c8414bbcf7ccb329bdb7651db65666fa84aeac4b48aa3891f3ed8f0178a70c6
   languageName: node
   linkType: hard
 
@@ -7907,7 +7799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:4.2.0, import-meta-resolve@npm:^4.0.0":
+"import-meta-resolve@npm:4.2.0, import-meta-resolve@npm:^4.0.0, import-meta-resolve@npm:^4.2.0":
   version: 4.2.0
   resolution: "import-meta-resolve@npm:4.2.0"
   checksum: 10c0/3ee8aeecb61d19b49d2703987f977e9d1c7d4ba47db615a570eaa02fe414f40dfa63f7b953e842cbe8470d26df6371332bfcf21b2fd92b0112f9fea80dde2c4c
@@ -8150,15 +8042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-subdir@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "is-subdir@npm:1.2.0"
-  dependencies:
-    better-path-resolve: "npm:1.0.0"
-  checksum: 10c0/03a03ee2ee6578ce589b1cfaf00e65c86b20fd1b82c1660625557c535439a7477cda77e20c62cda6d4c99e7fd908b4619355ae2d989f4a524a35350a44353032
-  languageName: node
-  linkType: hard
-
 "is-text-path@npm:^2.0.0":
   version: 2.0.0
   resolution: "is-text-path@npm:2.0.0"
@@ -8168,7 +8051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-windows@npm:^1.0.0, is-windows@npm:^1.0.1":
+"is-windows@npm:^1.0.1":
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
   checksum: 10c0/b32f418ab3385604a66f1b7a3ce39d25e8881dee0bd30816dc8344ef6ff9df473a732bcc1ec4e84fe99b2f229ae474f7133e8e93f9241686cfcf7eebe53ba7a5
@@ -8270,6 +8153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jju@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jju@npm:1.4.0"
+  checksum: 10c0/f3f444557e4364cfc06b1abf8331bf3778b26c0c8552ca54429bc0092652172fdea26cbffe33e1017b303d5aa506f7ede8571857400efe459cb7439180e2acad
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -8284,19 +8174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.6.1":
-  version: 3.15.1
-  resolution: "js-yaml@npm:3.15.1"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.3.0":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.0":
   version: 4.3.1
   resolution: "js-yaml@npm:4.3.1"
   dependencies:
@@ -8416,6 +8294,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "jsonc-parser@npm:3.3.1"
+  checksum: 10c0/269c3ae0a0e4f907a914bf334306c384aabb9929bd8c99f909275ebd5c2d3bc70b9bcd119ad794f339dec9f24b6a4ee9cd5a8ab2e6435e730ad4075388fc2ab6
+  languageName: node
+  linkType: hard
+
 "jsonc@npm:2.0.0":
   version: 2.0.0
   resolution: "jsonc@npm:2.0.0"
@@ -8478,6 +8363,16 @@ __metadata:
   version: 0.37.0
   resolution: "known-css-properties@npm:0.37.0"
   checksum: 10c0/e0ec08cae580e8833254b690971f73ec6f78ac461820a3c755b4a0b62c5b871501753b4aa60b30576a0f621ba44b231235cf9f35ab89e2e7de5448dfe0600241
+  languageName: node
+  linkType: hard
+
+"launch-editor@npm:^2.14.1":
+  version: 2.14.1
+  resolution: "launch-editor@npm:2.14.1"
+  dependencies:
+    picocolors: "npm:^1.1.1"
+    shell-quote: "npm:^1.8.4"
+  checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
   languageName: node
   linkType: hard
 
@@ -8561,15 +8456,6 @@ __metadata:
     "@npmcli/config": "npm:^8.0.0"
     import-meta-resolve: "npm:^4.0.0"
   checksum: 10c0/cbbd4e18472a0ed543b6d60e867a1e2aae385205fcaa76d300ab5a72697e057422cd1e6ff2ba19755c55a86b3d53e53b81a814c757be720895ba525d05f75797
-  languageName: node
-  linkType: hard
-
-"locate-path@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "locate-path@npm:5.0.0"
-  dependencies:
-    p-locate: "npm:^4.1.0"
-  checksum: 10c0/33a1c5247e87e022f9713e6213a744557a3e9ec32c5d0b5efb10aa3a38177615bf90221a5592674857039c1a0fd2063b82f285702d37b792d973e9e72ace6c59
   languageName: node
   linkType: hard
 
@@ -9148,7 +9034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.2.3, merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.2.3, merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
@@ -9761,13 +9647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mri@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "mri@npm:1.2.0"
-  checksum: 10c0/a3d32379c2554cf7351db6237ddc18dc9e54e4214953f3da105b97dc3babe0deb3ffe99cf409b38ea47cc29f9430561ba6b53b24ab8f9ce97a4b50409e4a50e7
-  languageName: node
-  linkType: hard
-
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -9844,20 +9723,6 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.5.0":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 
@@ -10084,26 +9949,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"outdent@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "outdent@npm:0.5.0"
-  checksum: 10c0/e216a4498889ba1babae06af84cdc4091f7cac86da49d22d0163b3be202a5f52efcd2bcd3dfca60a361eb3a27b4299f185c5655061b6b402552d7fcd1d040cff
-  languageName: node
-  linkType: hard
-
 "p-cancelable@npm:^2.0.0":
   version: 2.1.1
   resolution: "p-cancelable@npm:2.1.1"
   checksum: 10c0/8c6dc1f8dd4154fd8b96a10e55a3a832684c4365fb9108056d89e79fbf21a2465027c04a59d0d797b5ffe10b54a61a32043af287d5c4860f1e996cbdbc847f01
-  languageName: node
-  linkType: hard
-
-"p-filter@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-filter@npm:2.1.0"
-  dependencies:
-    p-map: "npm:^2.0.0"
-  checksum: 10c0/5ac34b74b3b691c04212d5dd2319ed484f591c557a850a3ffc93a08cb38c4f5540be059c6b10a185773c479ca583a91ea00c7d6c9958c815e6b74d052f356645
   languageName: node
   linkType: hard
 
@@ -10143,15 +9992,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-locate@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "p-locate@npm:4.1.0"
-  dependencies:
-    p-limit: "npm:^2.2.0"
-  checksum: 10c0/1b476ad69ad7f6059744f343b26d51ce091508935c1dbb80c4e0a2f397ffce0ca3a1f9f5cd3c7ce19d7929a09719d5c65fe70d8ee289c3f267cd36f2881813e9
-  languageName: node
-  linkType: hard
-
 "p-locate@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
@@ -10170,13 +10010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "p-map@npm:2.1.0"
-  checksum: 10c0/735dae87badd4737a2dd582b6d8f93e49a1b79eabbc9815a4d63a528d5e3523e978e127a21d784cccb637010e32103a40d2aaa3ab23ae60250b1a820ca752043
-  languageName: node
-  linkType: hard
-
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
@@ -10191,12 +10024,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-manager-detector@npm:^0.2.0":
-  version: 0.2.11
-  resolution: "package-manager-detector@npm:0.2.11"
-  dependencies:
-    quansync: "npm:^0.2.7"
-  checksum: 10c0/247991de461b9e731f3463b7dae9ce187e53095b7b94d7d96eec039abf418b61ccf74464bec1d0c11d97311f33472e77baccd4c5898f77358da4b5b33395e0b1
+"package-manager-detector@npm:^1.6.0, package-manager-detector@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "package-manager-detector@npm:1.8.0"
+  checksum: 10c0/4c8e2c47fdc874465d3b3b11934401db9d73470ccbdabeb092e46cb94abbc491d5befc8c271b5ea1ae9c6a881f44c2997e011873365bde9fd6c3dc001221ff7a
   languageName: node
   linkType: hard
 
@@ -10374,7 +10205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -10408,13 +10239,6 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 10c0/6abf7ab04941e6ac44cc55e9aca800aba4769407e8faf1d28a8adce44bfca1a0060c1e7c662c2641241c67367a80fc768d71a35391d7e5ffd15f0ee7d5ea74e0
-  languageName: node
-  linkType: hard
-
-"pify@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pify@npm:4.0.1"
-  checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
   languageName: node
   linkType: hard
 
@@ -10669,13 +10493,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quansync@npm:^0.2.7":
-  version: 0.2.11
-  resolution: "quansync@npm:0.2.11"
-  checksum: 10c0/cb9a1f8ebce074069f2f6a78578873ffedd9de9f6aa212039b44c0870955c04a71c3b1311b5d97f8ac2f2ec476de202d0a5c01160cb12bc0a11b7ef36d22ef56
-  languageName: node
-  linkType: hard
-
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -10721,18 +10538,6 @@ __metadata:
     json-parse-even-better-errors: "npm:^4.0.0"
     npm-normalize-package-bin: "npm:^4.0.0"
   checksum: 10c0/8a03509ae8e852f1abc4b109c1be571dd90ac9ea65d55433b2fe287e409113441a9b00df698288fe48aa786c1a2550569d47b5ab01ed83ada073d691d5aff582
-  languageName: node
-  linkType: hard
-
-"read-yaml-file@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "read-yaml-file@npm:1.1.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.5"
-    js-yaml: "npm:^3.6.1"
-    pify: "npm:^4.0.1"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10c0/85a9ba08bb93f3c91089bab4f1603995ec7156ee595f8ce40ae9f49d841cbb586511508bd47b7cf78c97f678c679b2c6e2c0092e63f124214af41b6f8a25ca31
   languageName: node
   linkType: hard
 
@@ -12050,7 +11855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.1.2":
+"safer-buffer@npm:^2.1.2":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -12100,7 +11905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.5":
+"semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.1, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -12143,7 +11948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3":
+"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.4":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
@@ -12218,6 +12023,13 @@ __metadata:
   bin:
     simple-git-hooks: cli.js
   checksum: 10c0/09631ce2cce5c6cf91f5a990bbefce88f95589ce112a601e2745b8e10ea951668c13f89b3fab2044506646380dcc91b618bb400d35142873a1990c4528b456bb
+  languageName: node
+  linkType: hard
+
+"sisteransi@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "sisteransi@npm:1.0.5"
+  checksum: 10c0/230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
   languageName: node
   linkType: hard
 
@@ -12337,16 +12149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spawndamnit@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "spawndamnit@npm:3.0.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.5"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10c0/a9821a59bc78a665bd44718dea8f4f4010bb1a374972b0a6a1633b9186cda6d6fd93f22d1e49d9944d6bb175ba23ce29036a4bd624884fb157d981842c3682f3
-  languageName: node
-  linkType: hard
-
 "spdx-correct@npm:^3.0.0":
   version: 3.2.0
   resolution: "spdx-correct@npm:3.2.0"
@@ -12402,13 +12204,6 @@ __metadata:
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 
@@ -12507,13 +12302,6 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.2.2"
   checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
-  languageName: node
-  linkType: hard
-
-"strip-bom@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-bom@npm:3.0.0"
-  checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
   languageName: node
   linkType: hard
 
@@ -12629,13 +12417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"term-size@npm:^2.1.0":
-  version: 2.2.1
-  resolution: "term-size@npm:2.2.1"
-  checksum: 10c0/89f6bba1d05d425156c0910982f9344d9e4aebf12d64bfa1f460d93c24baa7bc4c4a21d355fbd7153c316433df0538f64d0ae6e336cc4a69fdda4f85d62bc79d
-  languageName: node
-  linkType: hard
-
 "test-exclude@npm:^7.0.1":
   version: 7.0.2
   resolution: "test-exclude@npm:7.0.2"
@@ -12675,14 +12456,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.0":
+"tinyexec@npm:^1.0.0, tinyexec@npm:^1.3.0":
   version: 1.3.0
   resolution: "tinyexec@npm:1.3.0"
   checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -12735,13 +12516,6 @@ __metadata:
   dependencies:
     eslint-visitor-keys: "npm:^3.0.0"
   checksum: 10c0/e7687c8365b86aca570b8fa9681059b6b0b6b950edfe67716aa63c4fe056d7d8c23953e626add7e0531cfa03e6a1e55563214a7ce83dacf1d31d382d54827555
-  languageName: node
-  linkType: hard
-
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
@@ -13546,27 +13320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
 "whatwg-mimetype@npm:5.0.0":
   version: 5.0.0
   resolution: "whatwg-mimetype@npm:5.0.0"
   checksum: 10c0/eead164fe73a00dd82f817af6fc0bd22e9c273e1d55bf4bc6bdf2da7ad8127fca82ef00ea6a37892f5f5641f8e34128e09508f92126086baba126b9e0d57feb4
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -13711,7 +13468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.7.1":
+"yaml@npm:^2.0.0, yaml@npm:^2.7.1, yaml@npm:^2.9.0":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
## Summary

Drop support for Changesets v2 and Node < 22. Bump all `@changesets/*` dependencies to v3 and `@manypkg/get-packages` to v3.

Closes #249

## Breaking changes

- **Node engine requirement** bumped from `>=18.0.0` to `^22.11 || ^24 || >=26` to match Changesets v3
- **`@changesets/*` dependencies** bumped to v3 versions, which are ESM-only
- **`@manypkg/get-packages`** bumped to v3, changing the `Packages` and `Package` types (`tool` is now an object with `type` property, `root` renamed to `rootPackage`, `Package` now requires `relativeDir`)

## Bug fixes for Changesets v3 compatibility

- Handle the new `changeset version` exit code 1 when no unreleased changesets exist
- Detect published packages via the `CHANGESETS_OUTPUT` env var (NDJSON format), falling back to stdout "New tag:" parsing for Changesets v2
- Prevent creating empty release MRs when the version command produces no file changes — fall through to publish instead
- Use `ignoreReturnCode: true` on version and publish commands since v3 may exit non-zero in valid scenarios

## API changes from v3 dependencies

- `ValidationError` (removed in `@changesets/errors` v1) → `ExitError`
- `parse` from `@changesets/config` → `validateConfig` (returns `ParseResult` with `.config`)
- Default exports deprecated in favor of named exports (`readChangesets`, `assembleReleasePlan`, `parseChangesetFile`)
- `PreState.changesets` removed — filter by `pre/` prefix instead
- `packages.tool` is now an object (`tool.type`), `packages.root` → `packages.rootPackage`

## Checklist

- [x] Build passes (`yarn build`)
- [x] Typecheck passes (`yarn lint:tsc`)
- [x] ESLint passes (`yarn lint:es`)
- [x] Tests pass (`yarn test`)
- [x] Changeset added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Requires Node.js 22.11+, 24.x, or 26+.
  * Upgrades to Changesets v3; Changesets v2 is no longer supported.

* **New Features**
  * Supports Changesets v3 publish output and legacy publish-output parsing.
  * Publishes packages when versioning completes without file changes.
  * Reports publish command exit status.

* **Bug Fixes**
  * Improves configuration validation and pre-release changeset handling.
  * Prevents unnecessary merge requests when no files change.
  * Improves tag-push error handling and publish failure reporting.
  * Ensures tags and releases are created consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->